### PR TITLE
Valid coordinates

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -1434,7 +1434,7 @@ class CFBaseCheck(BaseCheck):
                 if each in space_time_non_coord_var_dim:
                     valid = False
                     dim_name = each
-                    continue
+                    break
                 elif each in space_time_coord_var:
                     valid = True
 


### PR DESCRIPTION
fixed check_independent_axis_dimensions . Renamed this result object from valid_coordinates to check_independent_axis_dimensions
