### PR TITLE
units_convert and conventions

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -405,13 +405,15 @@ class CFBaseCheck(BaseCheck):
         """
         2.6.1 the NUG defined global attribute Conventions to the string value "CF-1.6"
         """
+        valid_conventions = ['CF-1.0', 'CF-1.1', 'CF-1.2', 'CF-1.3',
+                             'CF-1.4', 'CF-1.5', 'CF-1.6']
         if hasattr(ds.dataset, 'Conventions'):
-            if getattr(ds.dataset, 'Conventions', '') == 'CF-1.6':
+            if getattr(ds.dataset, 'Conventions', '') in valid_conventions:
                 valid = True
-                reasoning = ['Conventions field is "CF-1.6"']
+                reasoning = ['Conventions field is "CF-1.x (x in 0-6)"']
             else:
                 valid = False
-                reasoning = ['Conventions field is not "CF-1.6"']
+                reasoning = ['Conventions field is not "CF-1.x (x in 0-6)"']
         else:
             valid = False
             reasoning = ['Conventions field is not present']
@@ -553,7 +555,7 @@ class CFBaseCheck(BaseCheck):
                     if std_units == 'm' and units in ['meter', 'meters']:
                         std_units = units
     
-                    if units != std_units and units not in ['degrees_north', 'degree_N', 'degreeN', 'degreesN', 'degrees_east', 'degree_E', 'degreeE', 'degreesE'] :
+                    if units != std_units and units not in ['degrees_north', 'degree_N', 'degreeN', 'degreesN', 'degrees_east', 'degree_E', 'degreeE', 'degreesE'] and not units_convertible(units, std_units):
                         msgs = ['units are %s, standard_name units should be %s' % (units, std_units)]
                         valid = False
                 else:

--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -250,12 +250,11 @@ def units_known(units):
     return True
 
 def units_convertible(units1, units2, reftimeistime=True):
-    try:
-        Converter(str(units1), str(units2))
-    except UdunitsError:
-        return False
-
-    return True
+    """Return True if a Unit representing the string units1 can be converted
+    to a Unit representing the string units2, else False."""
+    u1 = Unit(units1)
+    u2 = Unit(units2)
+    return u1.are_convertible(u2)
 
 def units_temporal(units):
     r = False


### PR DESCRIPTION
I have tested this compliance checker against a set of data files created by an application I trust.  Three issues came up:
1. the conventions attribute is CF-1.5
2. the units of measure for two coordinate variables are convertible to the canonical unit for the standard name 
3. the units of measure 'hours' were being picked up as a referenced temporal unit (like 'hours since 1970-01-01') which they are not, due to the way cf.util.units_convertible is implemented

I have made a small number of changes to adapt the checker to handle these cases.

This pull request is not ready to merge as there are test failures.  I would appreciate a little feedback on the logic and on whether there are any known test failures to help me with this change proposal.

many thanks
mark
