### PR TITLE
Using cf_units instead of udunitspy.

### DIFF
--- a/compliance_checker/acdd.py
+++ b/compliance_checker/acdd.py
@@ -4,7 +4,7 @@ import numpy as np
 from pkgutil import get_data
 
 from dateutil.parser import parse as parse_dt
-from udunitspy import Unit
+from cf_units import Unit
 
 from compliance_checker.base import BaseCheck, BaseNCCheck, check_has, score_group, Result
 from compliance_checker.cf.cf import _possiblexunits, _possibleyunits
@@ -15,7 +15,7 @@ class ACDDBaseCheck(BaseCheck):
     ###############################################################################
     #
     # HIGHLY RECOMMENDED
-    # 
+    #
     ###############################################################################
 
     @check_has(BaseCheck.HIGH)

--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -3,7 +3,7 @@ import os.path
 import itertools
 from collections import defaultdict
 from lxml import etree
-from udunitspy import Unit, UdunitsError, Converter
+from cf_units import Unit
 from netCDF4 import Dimension, Variable
 from pkgutil import get_data
 
@@ -24,7 +24,7 @@ _possiblez = ["depth", "DEPTH",
            "depths", "DEPTHS",
            "height", "HEIGHT",
            "altitude", "ALTITUDE",
-           "alt", "ALT", 
+           "alt", "ALT",
            "Alt", "Altitude",
            "h", "H",
            "s_rho", "S_RHO",
@@ -81,25 +81,25 @@ _possibleyunits = ['degrees_north',
                 'degreeN'
                     ]
 
-_possibletunits = ['day', 
-                'days', 
-                'd', 
-                'hour', 
-                'hours', 
-                'hr', 
-                'hrs', 
-                'h', 
-                'year', 
-                'years', 
-                'minute', 
-                'minutes', 
-                'm', 
-                'min', 
-                'mins', 
-                'second', 
-                'seconds', 
-                's', 
-                'sec', 
+_possibletunits = ['day',
+                'days',
+                'd',
+                'hour',
+                'hours',
+                'hr',
+                'hrs',
+                'h',
+                'year',
+                'years',
+                'minute',
+                'minutes',
+                'm',
+                'min',
+                'mins',
+                'second',
+                'seconds',
+                's',
+                'sec',
                 'secs'
                 ]
 
@@ -250,31 +250,25 @@ class StandardNameTable(object):
 
 def units_known(units):
     try:
-        Unit(str(units))
-    except UdunitsError:
+        Unit(units)
+    except ValueError:
         return False
     return True
+
 
 def units_convertible(units1, units2, reftimeistime=True):
     """Return True if a Unit representing the string units1 can be converted
     to a Unit representing the string units2, else False."""
     try:
-        Converter(str(units1), str(units2))
-    except UdunitsError:
+        u1 = Unit(units1)
+        u2 = Unit(units2)
+    except ValueError:
         return False
-
-    u1 = Unit(str(units1))
-    u2 = Unit(str(units2))
-    return u1.are_convertible(u2)
+    return u1.is_convertible(units2)
 
 def units_temporal(units):
-    r = False
-    try:
-        u = Unit('seconds since 1900-01-01')
-        r = u.are_convertible(str(units))
-    except UdunitsError:
-        return False
-    return r
+    u = Unit(units)
+    return u.is_time_reference()
 
 def map_axes(dim_vars, reverse_map=False):
     """
@@ -325,14 +319,14 @@ def is_time_variable(varname, var):
 def is_vertical_coordinate(var_name, var):
     """
     Determines if a variable is a vertical coordinate variable
-    
+
     4.3
     A vertical coordinate will be identifiable by: units of pressure; or the presence of the positive attribute with a
     value of up or down (case insensitive).  Optionally, the vertical type may be indicated additionally by providing
     the standard_name attribute with an appropriate value, and/or the axis attribute with the value Z.
     """
     # Known name
-    satisfied = var_name.lower() in _possiblez 
+    satisfied = var_name.lower() in _possiblez
     satisfied |= getattr(var, 'standard_name', '') in _possiblez
     # Is the axis set to Z?
     satisfied |= getattr(var, 'axis', '').lower() == 'z'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 OWSLib>=0.8.3
 Wicken>=0.1.2
 lxml>=3.2.1
-udunitspy==0.0.6
+cf_units==0.1.0
 requests>=2.2.1
 python-dateutil>=2.2


### PR DESCRIPTION
This PR replaces `udunitspy` with `cf_units`, making it possible to run compliance-checker on Windows.  The PR passes `python2 setup.py test`, but more tests are probably needed before merging.

The implementation here followed that of `udunitspy`, but with some optimizations made possible by the `cf_units` API.  

Unfortunately the file diff shows extra changes ("diff noise") due to leading blank spaces that I can fix if necessary. 

Closes #61 (and maybe #62).  It does not depend on swig which will make #65 easier.

(Also closes https://github.com/ioos/conda-recipes/issues/225.)