### PR TITLE
Fix travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ before_install:
     - source activate test
 
 script:
-    - py.test
+    - python setup.py test


### PR DESCRIPTION
This PR changes the test call from `py.test` to `python setup.py test`, somehow `py.test` was failing.  My guess is because it was trying to download all the dependencies from PyPI (and `cf_units` is not there yet).