### PR TITLE
Allow non-dtype vars in CF check_units, fixes #144

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -490,7 +490,7 @@ class CFBaseCheck(BaseCheck):
                continue
 
             # skip string type vars
-            if v.dtype.char == 'S':
+            if (isinstance(v.dtype, type) and issubclass(v.dtype, basestring)) or v.dtype.char == 'S':
                 continue
             
             # skip quality control vars


### PR DESCRIPTION
@DanielJMaher please pull/review.  @lukecampbell please review/merge.
