### PR TITLE
Update CF check fill value to modern style, fixes #147

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -397,7 +397,7 @@ class CFBaseCheck(BaseCheck):
                 valid     = not (v._FillValue >= rmin and v._FillValue <= rmax)
                 reasoning = []
                 if not valid:
-                    reasoning = ["%s must not be between %s and %s as specified by %s" % (v._FillValue, rmin, rmax, spec_by)]
+                    reasoning = ["%s must not be in valid range (%s to %s) as specified by %s" % (v._FillValue, rmin, rmax, spec_by)]
 
                 ret.append(Result(BaseCheck.HIGH, valid, ('fill_value', k, 'outside_valid_range'), msgs=reasoning))
 

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -399,7 +399,7 @@ class CFBaseCheck(BaseCheck):
                 if not valid:
                     reasoning = ["%s must not be in valid range (%s to %s) as specified by %s" % (v._FillValue, rmin, rmax, spec_by)]
 
-                ret.append(Result(BaseCheck.HIGH, valid, ('fill_value', k, 'outside_valid_range'), msgs=reasoning))
+                ret.append(Result(BaseCheck.HIGH, valid, ('_FillValue', k, 'outside_valid_range'), msgs=reasoning))
 
         return ret
 

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -386,16 +386,18 @@ class CFBaseCheck(BaseCheck):
 
                 if 'valid_range' in attrs:
                     rmin, rmax = v.valid_range
+                    spec_by = 'valid_range'
                 elif 'valid_min' in attrs and 'valid_max' in attrs:
                     rmin = v.valid_min
                     rmax = v.valid_max
+                    spec_by = 'valid_min/valid_max'
                 else:
                     continue
 
                 valid     = not (v._FillValue >= rmin and v._FillValue <= rmax)
                 reasoning = []
                 if not valid:
-                    reasoning = ["%s must not be between %s and %s" % (v._FillValue, rmin, rmax)]
+                    reasoning = ["%s must not be between %s and %s as specified by %s" % (v._FillValue, rmin, rmax, spec_by)]
 
                 ret.append(Result(BaseCheck.HIGH, valid, ('fill_value', k, 'outside_valid_range'), msgs=reasoning))
 

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -378,8 +378,7 @@ class CFBaseCheck(BaseCheck):
         """
         2.5.1 The _FillValue should be outside the range specified by valid_range (if used) for a variable.
         """
-        fails = []
-        checked = 0
+        ret = []
 
         for k, v in ds.dataset.variables.iteritems():
             if hasattr(v, '_FillValue'):
@@ -393,14 +392,14 @@ class CFBaseCheck(BaseCheck):
                 else:
                     continue
 
-                checked += 1
+                valid     = not (v._FillValue >= rmin and v._FillValue <= rmax)
+                reasoning = []
+                if not valid:
+                    reasoning = ["%s must not be between %s and %s" % (v._FillValue, rmin, rmax)]
 
-                if v._FillValue >= rmin and v._FillValue <= rmax:
-                    fails.append((k, "%s is between %s and %s" % (v._FillValue, rmin, rmax)))
-        if checked >= 1:
-            return Result(BaseCheck.HIGH, (checked - len(fails), checked), msgs=fails)
-        else:
-            return []
+                ret.append(Result(BaseCheck.HIGH, valid, ('fill_value', k, 'outside_valid_range'), msgs=reasoning))
+
+        return ret
 
     def check_conventions_are_cf_16(self, ds):
         """

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -171,8 +171,9 @@ class TestCF(unittest.TestCase):
         """
 
         dataset = self.get_pair(static_files['bad_data_type'])
-        result = self.cf.check_fill_value_outside_valid_range(dataset)
-        assert result.value == (1, 2)
+        results = self.cf.check_fill_value_outside_valid_range(dataset)
+        assert sum((result.value for result in results)) == 1
+        assert len(results) == 2
 
     def test_check_conventions_are_cf_16(self):
         """


### PR DESCRIPTION
Brings CF `check_value_outside_valid_range` in line with other checks.

```
fill_value                             :3:    47/48 :  
    PROFILE                            :3:     0/ 1 :  
        outside_valid_range            :3:     0/ 1 : 99999 must not be between
                                                      0 and 900000
```

instead of a single flat result with `(47/48)` and many messages (that weren't working properly anyway).