### PR TITLE
test on featureType value should be case insensitive

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -2767,7 +2767,7 @@ class CFBaseCheck(BaseCheck):
 
         role_list = [getattr(var, 'cf_role', '').split(' ') for name,var in ds.dataset.variables.iteritems() if hasattr(var, 'cf_role')]
         single_role = ['timeseries', 'profile', 'trajectory']
-        dual_role = ['timeseries', 'profile', 'trajectory','timeSeriesProfile', 'trajectoryProfile']
+        dual_role = ['timeseries', 'profile', 'trajectory','timeseriesprofile', 'trajectoryprofile']
         if getattr(ds.dataset, 'featureType', '').lower() in single_role and len(np.ravel(role_list)) == 1:
             reasoning = []
             valid = True


### PR DESCRIPTION
The list of strings dual_role should be lower case since we're trying to compare it against ```getattr(ds.dataset, 'featureType', '').lower()```.

At the moment this check is giving false result for the following featureType : timeSeriesProfile, trajectoryProfile.