### PR TITLE
Handle an exception in CF check_time_coordinate

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -1212,9 +1212,13 @@ class CFBaseCheck(BaseCheck):
                             ('time', k, 'has_units'))
             ret_val.append(result)
             correct_units = units_temporal(v.units)
+            reasoning = None
+            if not correct_units:
+                reasoning = ['%s doesn not have correct time units' % k]
             result = Result(BaseCheck.HIGH, \
                             correct_units,  \
-                            ('time', k, 'correct_units'))
+                            ('time', k, 'correct_units'),  \
+                            reasoning)
             ret_val.append(result)
 
         return ret_val

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -1199,11 +1199,7 @@ class CFBaseCheck(BaseCheck):
             if not has_units:
                 result = Result(BaseCheck.HIGH, \
                                 False,          \
-                                ('time', k, 'has_units'),['%s does not have the correct units'%k])
-                ret_val.append(result)
-                result = Result(BaseCheck.HIGH, \
-                                False,          \
-                                ('time', k, 'correct_units'),['%s does not have the correct units'%k])
+                                ('time', k, 'has_units'),['%s does not have units'%k])
                 ret_val.append(result)
                 continue
             # Correct and identifiable units

--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -267,7 +267,10 @@ def units_convertible(units1, units2, reftimeistime=True):
     return u1.is_convertible(units2)
 
 def units_temporal(units):
-    u = Unit(units)
+    try:
+        u = Unit(units)
+    except ValueError:
+        return False
     return u.is_time_reference()
 
 def map_axes(dim_vars, reverse_map=False):

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from compliance_checker.cf import CFBaseCheck, BaseCheck, dimless_vertical_coordinates
-from compliance_checker.cf.util import is_vertical_coordinate, is_time_variable, units_convertible
+from compliance_checker.cf.util import is_vertical_coordinate, is_time_variable, units_convertible, units_temporal
 from compliance_checker.base import DSPair
 from wicken.netcdf_dogma import NetCDFDogma
 from netCDF4 import Dataset
@@ -756,6 +756,10 @@ class TestCF(unittest.TestCase):
         self.assertTrue(units_convertible('hours', 'seconds'))
         self.assertFalse(units_convertible('hours', 'hours since 2000-01-01'))
 
+    def test_units_temporal(self):
+        self.assertTrue(units_temporal('hours since 2000-01-01'))
+        self.assertFalse(units_temporal('hours'))
+        self.assertFalse(units_temporal('days since the big bang'))
 
 
 def breakpoint(scope=None, global_scope=None):


### PR DESCRIPTION
If the file *units* attribute of a time variable contains a string that cannot be parsed by cf_units, the CF  `check_time_coordinate` method throws an exception, which is reported at the beginning of the output like this:
```
The following exceptions occured during the cf checker (possibly indicate compliance checker issues):
cf.check_time_coordinate: [UT_SYNTAX] Failed to parse unit "days since 1950-01-01 T00:00:00Z" 
```

This PR adds a unittest to test for this case, and fixes it by catching the exception in the `units_temporal` util method.

While I was at it, I also added a couple of tweaks to the reasoning messages returned by `check_time_coordinate` (see individual commit messages). Hope these make sense.