### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+sudo: false
+
 env:
     - CONDA="python=2.7"
 
@@ -8,9 +10,10 @@ before_install:
     - wget $URL -O miniconda.sh
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
-    - conda update --yes conda
+    - conda update --yes --all
     - conda config --add channels ioos --force
     - travis_retry conda create --yes -n test --file requirements.txt $CONDA
+    - travis_retry conda install --yes pytest
     - source activate test
 
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ OWSLib>=0.8.3
 petulant-bear>=0.1.3
 Wicken>=0.1.2
 lxml>=3.2.1
-cf_units==0.1.0
+cf_units==0.1.1
 requests>=2.2.1
 python-dateutil>=2.2
 Jinja2>=2.7.3


### PR DESCRIPTION
- `sudo: false` moves from the old travis to the new and faster travis
- `conda update --yes --all` updates everything rather than just conda
- `cf_units==0.1.1` This is the real fix.  The previous version had a baked conda numpy string for NP19 and the rest of the packages were compiled against numpy > 1.10.0.