### PR TITLE
Update `flag_values` type mismatch message

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -779,7 +779,9 @@ class CFBaseCheck(BaseCheck):
             if flag_values is not None:
                 # flag_values must be a list (array), not just a single value
                 result_name = '§3.5 Flags and flag attributes'
-                fvlist = Result(BaseCheck.HIGH, isinstance(flag_values, np.ndarray), result_name)
+                fvlist = Result(BaseCheck.HIGH, isinstance(flag_values,
+                                                           np.ndarray),
+                                result_name)
                 if not fvlist.value:
                     fvlist.msgs = ['flag_values must be a list']
                     # convert to an array so the remaining checks can be applied
@@ -787,9 +789,13 @@ class CFBaseCheck(BaseCheck):
                 ret_val.append(fvlist)
 
                 # 1) flags_values attribute must have same type as variable to which it is attached
-                fvr = Result(BaseCheck.HIGH, flag_values.dtype == v.dtype, name='§3.5 Flags and flag attributes')
+                fvr = Result(BaseCheck.HIGH, flag_values.dtype == v.dtype,
+                             name='§3.5 Flags and flag attributes')
                 if not fvr.value:
-                    fvr.msgs = ['flag_values attr does not have same type as var (fv: %s, v: %s)' % (flag_values.dtype, v.dtype)]
+                    fvr.msgs = [("'flag_values' attribute for variable '%s'" +\
+                                " does not have same type " +\
+                                "(fv: %s, v: %s)")
+                                % (v.name, flag_values.dtype, v.dtype)]
 
                 ret_val.append(fvr)
 

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -285,8 +285,10 @@ class TestCF(unittest.TestCase):
         self.assertEqual(scored, 46)
         self.assertEqual(out_of, 59)
         self.assertEqual(messages.count('flag_values must be a list'), 6)
-        self.assertEqual(messages.count('flag_values attr does not have same type as var (fv: int8, v: int16)'), 6)
-        self.assertEqual(messages.count('flag_values attr does not have same type as var (fv: <U1, v: int16)'), 1)
+        m_str = r"'flag_values' attribute for variable '\w+' does not have same type \(fv: [<>]?\w+, v: [<>]?\w+\)"
+        # make sure flag_values attribute where not equal to variable type
+        # has the proper message
+        self.assertEqual(sum(bool(re.match(m_str, msg)) for msg in messages), 7)
 
     def test_check_bad_units(self):
 


### PR DESCRIPTION
Updates messages for `flag_values` attribute where attribute type is not
the same as the values in contained within the parent variable to
include the variable name.

Fixes #192.