### PR TITLE
Force Results.value to be bool or 2-tuple

### DIFF
--- a/compliance_checker/base.py
+++ b/compliance_checker/base.py
@@ -89,7 +89,8 @@ class Result(object):
     Holds the result of a check method.
 
     Stores such information as the check's value (True, False, a 2-tuple of (pass, total) or None for a skip),
-    weight of the check, any granular messages, or a hierarchy of results.
+    weight of the check, any granular messages, or a hierarchy of results. If given value is not a tuple, it
+    is cast as a boolean using the bool() function.
 
     Stores the checker instance and the check method that produced this result.
     """
@@ -97,7 +98,11 @@ class Result(object):
     def __init__(self, weight=BaseCheck.MEDIUM, value=None, name=None, msgs=None, children=None, checker=None, check_method=None):
 
         self.weight = weight
-        self.value  = value
+        if isinstance(value, tuple):
+            assert len(value)==2, 'Result value must be 2-tuple or boolean!'
+            self.value = value
+        else:
+            self.value = bool(value)
         self.name   = name
         self.msgs   = msgs or []
 

--- a/compliance_checker/tests/test_suite.py
+++ b/compliance_checker/tests/test_suite.py
@@ -1,6 +1,8 @@
 from compliance_checker import acdd
 from pkg_resources import resource_filename
 from compliance_checker.suite import CheckSuite
+from compliance_checker.base import Result, BaseCheck
+import numpy as np
 import unittest
 
 static_files = {
@@ -64,3 +66,19 @@ class TestSuite(unittest.TestCase):
             score_list, points, out_of = cs.standard_output(limit, checker, groups)
             # This asserts that print is able to generate all of the unicode output
             cs.non_verbose_output_generation(score_list, groups, limit, points, out_of)
+
+    def test_score_grouping(self):
+        # Testing the grouping of results for output, which can fail
+        # if some assumptions are not met, e.g. if a Result object has
+        # a value attribute of unexpected type
+        cs = CheckSuite()
+        res = [Result(BaseCheck.MEDIUM, True, 'one'),
+               Result(BaseCheck.MEDIUM, (1, 3), 'one'),
+               Result(BaseCheck.MEDIUM, True, 'two'),
+               Result(BaseCheck.MEDIUM, np.isnan(1), 'two')  # value is type numpy.bool_
+        ]
+        score = cs.scores(res)
+        self.assertEqual(score[0].name, 'one')
+        self.assertEqual(score[0].value, (2, 4))
+        self.assertEqual(score[1].name, 'two')
+        self.assertEqual(score[1].value, (1, 2))


### PR DESCRIPTION
The value of a Result object is expected to be either of type `tuple` or `bool`, but there is nothing enforcing this. While this is true most of the time, in the IMOS check suite we've created some Results having a value of type `numpy.bool_` (e.g. the result of `numpy.all()`). This didn't cause a problem earlier, but since da674bcc5dcc5745394e7dea1eafd9b5a376a54c it breaks because `_translate_value()` (in suite.py) returns such a value unchanged, while its output is expected to always be a tuple.

I've added a unittest to demonstrate this issue, and suggested a change to the `Result` object to ensure that the `value` attribute is always one of the expected types.