### PR TITLE
Allow Result.value = None

### DIFF
--- a/compliance_checker/base.py
+++ b/compliance_checker/base.py
@@ -101,7 +101,10 @@ class Result(object):
     def __init__(self, weight=BaseCheck.MEDIUM, value=None, name=None, msgs=None, children=None, checker=None, check_method=None):
 
         self.weight = weight
-        if isinstance(value, tuple):
+
+        if value is None:
+            self.value = None
+        elif isinstance(value, tuple):
             assert len(value)==2, 'Result value must be 2-tuple or boolean!'
             self.value = value
         else:

--- a/compliance_checker/tests/test_suite.py
+++ b/compliance_checker/tests/test_suite.py
@@ -76,6 +76,7 @@ class TestSuite(unittest.TestCase):
         cs = CheckSuite()
         res = [Result(BaseCheck.MEDIUM, True, 'one'),
                Result(BaseCheck.MEDIUM, (1, 3), 'one'),
+               Result(BaseCheck.MEDIUM, None, 'one'),
                Result(BaseCheck.MEDIUM, True, 'two'),
                Result(BaseCheck.MEDIUM, np.isnan(1), 'two')  # value is type numpy.bool_
         ]


### PR DESCRIPTION
Comment in the definition of the `Result` object (in base.py) suggest a value of `None` can be used to signify a skipped test. I missed this in #270. Here is an update to allow for that, if it is deemed relevant.