### PR TITLE
Add netCDF4 to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ isodate==0.5.4
 Jinja2>=2.7.3
 setuptools>=15.0
 pygeoif==0.6
+netCDF4>=1.2.2


### PR DESCRIPTION
This was an omission after removing Wicken, which depended on it.