### PR TITLE
Avoid UnicodeEncodeError when checker output is redirected

### DIFF
--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -21,6 +21,13 @@ except:
 from datetime import datetime
 import requests
 import textwrap
+import codecs
+
+# Ensure output is encoded as Unicode when checker output is redirected or piped
+if sys.stdout.encoding is None:
+    sys.stdout = codecs.getwriter('utf8')(sys.stdout)
+if sys.stderr.encoding is None:
+    sys.stderr = codecs.getwriter('utf8')(sys.stderr)
 
 
 class CheckSuite(object):


### PR DESCRIPTION
The checker is running fine in my (Linux) terminal, but when I try to redirect the output to a file, this happens:
```
$ compliance-checker -t=cf file.nc >/tmp/cc.out
Running Compliance Checker on the dataset from: file.nc
Traceback (most recent call last):
  File "/sw/anaconda/envs/cc/bin/compliance-checker", line 9, in <module>
    load_entry_point('compliance-checker', 'console_scripts', 'compliance-checker')()
  File "/sw/chef/src/compliance-checker/cchecker.py", line 56, in main
    args.format)
  File "/sw/chef/src/compliance-checker/compliance_checker/runner.py", line 44, in run_checker
    groups = cls.stdout_output(cs, score_groups, verbose, limit)
  File "/sw/chef/src/compliance-checker/compliance_checker/runner.py", line 74, in stdout_output
    cs.non_verbose_output_generation(score_list, groups, limit, points, out_of)
  File "/sw/chef/src/compliance-checker/compliance_checker/suite.py", line 340, in non_verbose_output_generation
    print('%-40s:%s:%6s/%1s'  % (score_list[x][0][0:39], score_list[x][1], score_list[x][2][0], score_list[x][2][1]))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xa7' in position 0: ordinal not in range(128)
```

Apparently the problem is that when I redirect output, Python sets the output encoding to `None` (which presumably defaults to ascii). Several solutions are suggested (e.g. [here](http://stackoverflow.com/questions/492483/setting-the-correct-encoding-when-piping-stdout-in-python), and [here](http://chase-seibert.github.io/blog/2014/01/12/python-unicode-console-output.html)). One of them is to force `stdout` and `stderr` encoding to unicode, which is what this PR does. Since we're explicitly trying to print unicode, this seems sensible.

Alternatively, this can be done using an environment variable (`PYTHONIOENCODING='UTF-8'`), so if you prefer not to set this in the code, we can just use that.