### PR TITLE
Add code version when listing check suites

### DIFF
--- a/cchecker.py
+++ b/cchecker.py
@@ -44,9 +44,10 @@ def main():
         return 0
 
     if args.list_tests:
-        print("IOOS compliance checker available checker suites:")
+        print("IOOS compliance checker available checker suites (code version):")
         for checker in sorted(check_suite.checkers.keys()):
-            print(" -", checker)
+            version = getattr(check_suite.checkers[checker], '_cc_checker_version', "???")
+            print(" - {} ({})".format(checker, version))
         return 0
 
     return_values = []


### PR DESCRIPTION
Since we now have check suites from plug-ins that have their own code version (the `_cc_checker_version` attribute), independent of the core checker code, the user may want to see what versions are in use.

Here I've added the code version to the output from the `--list-tests` command-line argument. Alternatively, it could be added to the `--version` output.