### PR TITLE
Dynamically download specified cf standard name table

### DIFF
--- a/cchecker.py
+++ b/cchecker.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 import argparse
 import sys
 from compliance_checker.runner import ComplianceChecker, CheckSuite
+from compliance_checker.cf.util import download_cf_standard_name_table
 from compliance_checker import __version__
 
 
@@ -36,6 +37,7 @@ def main():
     parser.add_argument('dataset_location', nargs='*',
                         help="Defines the location of the dataset to be checked.")
     parser.add_argument('-l', '--list-tests', action='store_true', help='List the available tests')
+    parser.add_argument('-d', '--download-standard-names', help='Specify a version of the cf standard name table to download as packaged version')
 
     args = parser.parse_args()
 
@@ -49,6 +51,9 @@ def main():
             version = getattr(check_suite.checkers[checker], '_cc_checker_version', "???")
             print(" - {} ({})".format(checker, version))
         return 0
+
+    if args.download_standard_names:
+        download_cf_standard_name_table(args.download_standard_names)
 
     return_values = []
     had_errors = []

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -9,7 +9,7 @@ import os
 
 from compliance_checker.base import BaseCheck, BaseNCCheck, score_group, Result
 from compliance_checker.cf.appendix_d import dimless_vertical_coordinates
-from compliance_checker.cf.util import NCGraph, StandardNameTable, units_known, units_convertible, units_temporal, map_axes, find_coord_vars, is_time_variable, is_vertical_coordinate, download_cf_standard_name_table, _possiblet, _possiblez, _possiblex, _possibley, _possibleaxis, _possibleaxisunits
+from compliance_checker.cf.util import NCGraph, StandardNameTable, units_known, units_convertible, units_temporal, map_axes, find_coord_vars, is_time_variable, is_vertical_coordinate, create_cached_data_dir, download_cf_standard_name_table, _possiblet, _possiblez, _possiblex, _possibley, _possibleaxis, _possibleaxisunits
 
 try:
     basestring
@@ -133,7 +133,7 @@ class CFBaseCheck(BaseCheck):
         self._metadata_vars  = defaultdict(list)
         self._boundary_vars  = defaultdict(dict)
 
-        self._std_names      = StandardNameTable('data/cf-standard-name-table.xml')
+        self._std_names      = StandardNameTable()
 
     ################################################################################
     #
@@ -159,7 +159,7 @@ class CFBaseCheck(BaseCheck):
 
         # Try to parse this attribute to get version
         version = None
-        if 'CF Standard Name Table' in standard_name_vocabulary:
+        if 'cf standard name table' in standard_name_vocabulary.lower():
             version = standard_name_vocabulary.split()[-1]
         else:
             # Can't parse the attribute, use the packaged version
@@ -174,12 +174,12 @@ class CFBaseCheck(BaseCheck):
 
         # Try to download the version specified
         try:
-            location = 'compliance_checker/data/cf-standard-name-table-{0}.xml'.format(version)  # (don't overwrite package location)
+            data_directory = create_cached_data_dir()
+            location = os.path.join(data_directory, 'cf-standard-name-table-test-{0}.xml'.format(version))
             # Did we already download this before?
             if not os.path.isfile(location):
                 download_cf_standard_name_table(version, location)
-            resource_name = location.split('compliance_checker/')[1]  # relative to package
-            self._std_names = StandardNameTable(resource_name)
+            self._std_names = StandardNameTable(location)
             return 1
         except Exception:
             # There was an error downloading the CF table. That's ok, we'll just use the packaged version

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -5,10 +5,11 @@ import re
 from functools import wraps
 from collections import defaultdict
 import numpy as np
+import os
 
 from compliance_checker.base import BaseCheck, BaseNCCheck, score_group, Result
 from compliance_checker.cf.appendix_d import dimless_vertical_coordinates
-from compliance_checker.cf.util import NCGraph, StandardNameTable, units_known, units_convertible, units_temporal, map_axes, find_coord_vars, is_time_variable, is_vertical_coordinate, _possiblet, _possiblez, _possiblex, _possibley, _possibleaxis, _possibleaxisunits
+from compliance_checker.cf.util import NCGraph, StandardNameTable, units_known, units_convertible, units_temporal, map_axes, find_coord_vars, is_time_variable, is_vertical_coordinate, download_cf_standard_name_table, _possiblet, _possiblez, _possiblex, _possibley, _possibleaxis, _possibleaxisunits
 
 try:
     basestring
@@ -132,7 +133,7 @@ class CFBaseCheck(BaseCheck):
         self._metadata_vars  = defaultdict(list)
         self._boundary_vars  = defaultdict(dict)
 
-        self._std_names      = StandardNameTable('cf-standard-name-table.xml')
+        self._std_names      = StandardNameTable('data/cf-standard-name-table.xml')
 
     ################################################################################
     #
@@ -146,6 +147,43 @@ class CFBaseCheck(BaseCheck):
         self._find_clim_vars(ds)
         self._find_boundary_vars(ds)
         self._find_metadata_vars(ds)
+        self._find_cf_standard_name_table(ds)
+
+    def _find_cf_standard_name_table(self, ds):
+        """
+        Parse out the :standard_name_vocabulary attribute and download that version of
+        the cf standard name table
+        """
+        # Get the standard name vocab
+        standard_name_vocabulary = getattr(ds, 'standard_name_vocabulary', '')
+
+        # Try to parse this attribute to get version
+        version = None
+        if 'CF Standard Name Table' in standard_name_vocabulary:
+            version = standard_name_vocabulary.split()[-1]
+        else:
+            # Can't parse the attribute, use the packaged version
+            return 0
+
+        if version.startswith('v'):  # i.e 'v34' -> '34' drop the v
+            version = version[1:]
+
+        # If the packaged version is what we're after, then we're good
+        if version == self._std_names._version:
+            return 0
+
+        # Try to download the version specified
+        try:
+            location = 'compliance_checker/data/cf-standard-name-table-%s.xml' % (version)  # (don't overwrite package location)
+            # Did we already download this before?
+            if not os.path.isfile(location):
+                download_cf_standard_name_table(version, location)
+            resource_name = location.split('compliance_checker/')[1]  # relative to package
+            self._std_names = StandardNameTable(resource_name)
+            return 1
+        except Exception:
+            # There was an error downloading the CF table. That's ok, we'll just use the packaged version
+            return 0
 
     def _find_coord_vars(self, ds, refresh=False):
         """

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -174,7 +174,7 @@ class CFBaseCheck(BaseCheck):
 
         # Try to download the version specified
         try:
-            location = 'compliance_checker/data/cf-standard-name-table-%s.xml' % (version)  # (don't overwrite package location)
+            location = 'compliance_checker/data/cf-standard-name-table-{0}.xml'.format(version)  # (don't overwrite package location)
             # Did we already download this before?
             if not os.path.isfile(location):
                 download_cf_standard_name_table(version, location)

--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -1,15 +1,13 @@
 import itertools
-try:
-    from urllib import urlretrieve
-except:
-    from urllib.request import urlretrieve
 import requests
+import os
 from copy import deepcopy
 from collections import defaultdict
 from lxml import etree
 from cf_units import Unit
 from netCDF4 import Dimension, Variable
 from pkgutil import get_data
+from pkg_resources import resource_filename
 
 # copied from paegan
 # paegan may depend on these later
@@ -260,8 +258,16 @@ class StandardNameTable(object):
 
             return vals[0].text
 
-    def __init__(self, resource_name):
-        resource_text = get_data("compliance_checker", resource_name)
+    def __init__(self, cached_location=None):
+        if cached_location:
+            try:
+                with open(cached_location, 'r') as fp:
+                    resource_text = fp.read()
+            except Exception:
+                resource_text = get_data("compliance_checker", "data/cf-standard-name-table.xml")
+        else:
+            resource_text = get_data("compliance_checker", "data/cf-standard-name-table.xml")
+
         parser = etree.XMLParser(remove_blank_text=True)
         self._root = etree.fromstring(resource_text, parser)
 
@@ -309,17 +315,30 @@ def download_cf_standard_name_table(version, location=None):
     '''
 
     if location is None:  # This case occurs when updating the packaged version from command line
-        location = 'compliance_checker/data/cf-standard-name-table.xml'
+        location = resource_filename('compliance_checker', 'data/cf-standard-name-table.xml')
 
     url = "http://cfconventions.org/Data/cf-standard-names/{0}/src/cf-standard-name-table.xml".format(version)
-    rhead = requests.head(url, allow_redirects=True)
-    if rhead.status_code == 200:
+    r = requests.get(url, allow_redirects=True)
+    if r.status_code == 200:
         print("Downloading cf-standard-names table version {0} from: {1}".format(version, url))
-        urlretrieve(url, location)
+        with open(location, 'wb') as f:
+            f.write(r.content)
     else:
-        raise Exception("Could not find specified cf-standard-names table version {0} from: {1}".format(version, url))
+        r.raise_for_status()
     return
 
+def create_cached_data_dir():
+    '''
+    Returns the path to the data directory to download CF standard names.
+    Use $XDG_DATA_HOME.
+    '''
+    writable_directory = os.path.join(os.path.expanduser('~'), '.local', 'share')
+    data_directory = os.path.join(os.environ.get("XDG_DATA_HOME", writable_directory),
+                                  'compliance-checker')
+    if not os.path.isdir(data_directory):
+        os.mkdir(data_directory)
+
+    return data_directory
 
 def units_known(units):
     try:

--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -336,7 +336,7 @@ def create_cached_data_dir():
     data_directory = os.path.join(os.environ.get("XDG_DATA_HOME", writable_directory),
                                   'compliance-checker')
     if not os.path.isdir(data_directory):
-        os.mkdir(data_directory)
+        os.makedirs(data_directory)
 
     return data_directory
 

--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -1,5 +1,8 @@
 import itertools
-import urllib
+try:
+    from urllib import urlretrieve
+except:
+    from urllib.request import urlretrieve
 import requests
 from copy import deepcopy
 from collections import defaultdict
@@ -312,7 +315,7 @@ def download_cf_standard_name_table(version, location=None):
     rhead = requests.head(url, allow_redirects=True)
     if rhead.status_code == 200:
         print("Downloading cf-standard-names table version {0} from: {1}".format(version, url))
-        urllib.urlretrieve(url, location)
+        urlretrieve(url, location)
     else:
         raise Exception("Could not find specified cf-standard-names table version {0} from: {1}".format(version, url))
     return

--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -308,13 +308,13 @@ def download_cf_standard_name_table(version, location=None):
     if location is None:  # This case occurs when updating the packaged version from command line
         location = 'compliance_checker/data/cf-standard-name-table.xml'
 
-    url = "http://cfconventions.org/Data/cf-standard-names/%s/src/cf-standard-name-table.xml" % (version)
+    url = "http://cfconventions.org/Data/cf-standard-names/{0}/src/cf-standard-name-table.xml".format(version)
     rhead = requests.head(url, allow_redirects=True)
     if rhead.status_code == 200:
-        print "Downloading cf-standard-names table version %s from: %s" % (version, url)
+        print("Downloading cf-standard-names table version {0} from: {1}".format(version, url))
         urllib.urlretrieve(url, location)
     else:
-        raise Exception("Could not find specified cf-standard-names table version %s from: %s" % (version, url))
+        raise Exception("Could not find specified cf-standard-names table version {0} from: {1}".format(version, url))
     return
 
 

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -2,7 +2,7 @@
 
 from compliance_checker.suite import CheckSuite
 from compliance_checker.cf import CFBaseCheck, dimless_vertical_coordinates
-from compliance_checker.cf.util import is_vertical_coordinate, is_time_variable, units_convertible, units_temporal, StandardNameTable, download_cf_standard_name_table
+from compliance_checker.cf.util import is_vertical_coordinate, is_time_variable, units_convertible, units_temporal, StandardNameTable, create_cached_data_dir, download_cf_standard_name_table
 from netCDF4 import Dataset
 from tempfile import gettempdir
 from compliance_checker.tests.resources import STATIC_FILES
@@ -252,13 +252,14 @@ class TestCF(unittest.TestCase):
         Test that a user can download a specific standard name table
         """
         version = '35'
-        location = 'compliance_checker/data/cf-standard-name-table-test-{0}.xml'.format(version)
+
+        data_directory = create_cached_data_dir()
+        location = os.path.join(data_directory, 'cf-standard-name-table-test-{0}.xml'.format(version))
         download_cf_standard_name_table(version, location)
 
         # Test that the file now exists in location and is the right version
         self.assertTrue(os.path.isfile(location))
-        resource_name = location.split('compliance_checker/')[1]  # relative to package
-        std_names = StandardNameTable(resource_name)
+        std_names = StandardNameTable(location)
         self.assertEqual(std_names._version, version)
         self.addCleanup(os.remove, location)
 

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -2,7 +2,7 @@
 
 from compliance_checker.suite import CheckSuite
 from compliance_checker.cf import CFBaseCheck, dimless_vertical_coordinates
-from compliance_checker.cf.util import is_vertical_coordinate, is_time_variable, units_convertible, units_temporal, NCGraph
+from compliance_checker.cf.util import is_vertical_coordinate, is_time_variable, units_convertible, units_temporal, StandardNameTable, download_cf_standard_name_table
 from netCDF4 import Dataset
 from tempfile import gettempdir
 from compliance_checker.tests.resources import STATIC_FILES
@@ -10,6 +10,7 @@ from compliance_checker.tests.resources import STATIC_FILES
 import unittest
 import os
 import re
+
 
 class MockVariable(object):
     '''
@@ -245,6 +246,21 @@ class TestCF(unittest.TestCase):
         result = self.cf.check_standard_name(dataset)
         for each in result:
             self.assertFalse(each.value)
+
+    def test_download_standard_name_table(self):
+        """
+        Test that a user can download a specific standard name table
+        """
+        version = '35'
+        location = 'compliance_checker/data/cf-standard-name-table-test-%s.xml' % (version)
+        download_cf_standard_name_table(version, location)
+
+        # Test that the file now exists in location and is the right version
+        self.assertTrue(os.path.isfile(location))
+        resource_name = location.split('compliance_checker/')[1]  # relative to package
+        std_names = StandardNameTable(resource_name)
+        self.assertEqual(std_names._version, version)
+        self.addCleanup(os.remove, location)
 
     def test_check_flags(self):
         dataset = self.load_dataset(STATIC_FILES['self_referencing'])

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -252,7 +252,7 @@ class TestCF(unittest.TestCase):
         Test that a user can download a specific standard name table
         """
         version = '35'
-        location = 'compliance_checker/data/cf-standard-name-table-test-%s.xml' % (version)
+        location = 'compliance_checker/data/cf-standard-name-table-test-{0}.xml'.format(version)
         download_cf_standard_name_table(version, location)
 
         # Test that the file now exists in location and is the right version


### PR DESCRIPTION
@lukecampbell @daf @kwilcox Can one of you guys review please?

This PR addresses https://github.com/ioos/compliance-checker/issues/247.

During the CF test, if a file has a particular version of the cf standard name table specified in the global attributes (i.e. ```:standard_name_vocabulary = "CF Standard Name Table v30" ;```) that doesn't match the packaged version, it will try to download the specified version. If it fails, it will fall back to packaged version.

This PR also adds ability to update the packaged version by using the 'd' switch and passing in the version you want to fetch.
```
python cchecker.py -d 34
```