### PR TITLE
Allows output of text to file

### DIFF
--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -315,10 +315,6 @@ class CheckSuite(object):
 
         return score_list, points, out_of
 
-    # TODO: These methods for output generation could use a refactor to simply
-    #       generate a string and handle output as necessary instead of a
-    #       large number of print functions.  Perhaps use something like a
-    #       Jinja2 template?
     def standard_output(self, limit, check_name, groups):
         """
         Generates the Terminal Output for Standard cases

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -315,6 +315,10 @@ class CheckSuite(object):
 
         return score_list, points, out_of
 
+    # TODO: These methods for output generation could use a refactor to simply
+    #       generate a string and handle output as necessary instead of a
+    #       large number of print functions.  Perhaps use something like a
+    #       Jinja2 template?
     def standard_output(self, limit, check_name, groups):
         """
         Generates the Terminal Output for Standard cases

--- a/compliance_checker/tests/test_cli.py
+++ b/compliance_checker/tests/test_cli.py
@@ -91,3 +91,24 @@ class TestCLI(TestCase):
         )
 
         assert os.stat(path).st_size > 0
+
+    def test_json_output(self):
+        '''
+        Tests that the 'text' output can be redirected to file with arguments
+        to the command line
+        '''
+
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        self.addCleanup(os.remove, path)
+
+        return_value, errors = ComplianceChecker.run_checker(
+            ds_loc=STATIC_FILES['conv_bad'],
+            verbose=0,
+            criteria='strict',
+            checker_names=['cf'],
+            output_filename=path,
+            output_format='text'
+        )
+
+        assert os.stat(path).st_size > 0


### PR DESCRIPTION
Allows 'text' format to be output to file with the `-o` option, i.e.
`compliance-checker -t acdd -f text -o cc_results.txt ncfile.nc`
Fixes #290.