### PR TITLE
Fixes json output when using multiple score groups

### DIFF
--- a/compliance_checker/runner.py
+++ b/compliance_checker/runner.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import traceback
 import sys
 import io
+import json
 
 from contextlib import contextmanager
 from compliance_checker.suite import CheckSuite
@@ -134,16 +135,19 @@ class ComplianceChecker(object):
         @param ds_loc          Location of the source dataset
         @param limit           The degree of strictness, 1 being the strictest, and going up from there.
         '''
-        for checker, rpair in score_groups.items():
+        results = {}
+        for i, (checker, rpair) in enumerate(score_groups.items()):
             groups, errors = rpair
-            if output_filename == '-':
-                f = io.StringIO()
-                cs.json_output(checker, groups, f, ds_loc, limit)
-                f.seek(0)
-                print(f.read())
-            else:
-                with io.open(output_filename, 'w', encoding='utf8') as f:
-                    cs.json_output(checker, groups, f, ds_loc, limit)
+            results[checker] = cs.dict_output(
+                checker, groups, ds_loc, limit
+            )
+        json_results = json.dumps(results, indent=2, ensure_ascii=False)
+
+        if output_filename == '-':
+            print(json_results)
+        else:
+            with io.open(output_filename, 'w', encoding='utf8') as f:
+                f.write(json_results)
 
         return groups
 

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -244,22 +244,18 @@ class CheckSuite(object):
         aggregates['source_name']       = source_name
         return aggregates
 
-    def json_output(self, check_name, groups, file_object, source_name, limit):
+    def dict_output(self, check_name, groups, source_name, limit):
         '''
         Builds the results into a JSON structure and writes it to the file buffer.
 
         @param check_name      The test which was run
         @param groups          List of results from compliance checker
         @param output_filename Path to file to save output
-        @param file_object     A python file object where the output should be written to
         @param source_name     Source of the dataset, used for title
         @param limit           Integer value for limiting output
         '''
         aggregates = self.build_structure(check_name, groups, source_name, limit)
-        aggregates = self.serialize(aggregates)
-        json_string = json.dumps(aggregates, ensure_ascii=False)
-        file_object.write(json_string)
-        return
+        return self.serialize(aggregates)
 
     def serialize(self, o):
         '''

--- a/compliance_checker/tests/test_cli.py
+++ b/compliance_checker/tests/test_cli.py
@@ -4,6 +4,9 @@
 Tests for command line output and parsing
 
 '''
+import io
+import sys
+import json
 
 from unittest import TestCase
 from compliance_checker.runner import ComplianceChecker, CheckSuite
@@ -18,6 +21,13 @@ class TestCLI(TestCase):
     '''
     Tests various functions and aspects of the command line tool and runner
     '''
+
+    def setUp(self):
+        _, self.path = tempfile.mkstemp()
+
+    def tearDown(self):
+        if os.path.isfile(self.path):
+            os.remove(self.path)
 
     def shortDescription(self):
         return None
@@ -37,78 +47,124 @@ class TestCLI(TestCase):
         '''
         Tests that the checker is capable of producing HTML with unicode characters
         '''
-
-        fd, path = tempfile.mkstemp()
-        os.close(fd)
-        self.addCleanup(os.remove, path)
         return_value, errors = ComplianceChecker.run_checker(
             ds_loc=STATIC_FILES['2dim'],
             verbose=0,
             criteria='strict',
             checker_names=['acdd'],
-            output_filename=path,
+            output_filename=self.path,
             output_format='html'
         )
 
-        assert os.stat(path).st_size > 0
+        assert os.stat(self.path).st_size > 0
 
     def test_unicode_cf_html(self):
         '''
         Tests that the CF checker can produce HTML output with unicode characters
         '''
-
-        fd, path = tempfile.mkstemp()
-        os.close(fd)
-        self.addCleanup(os.remove, path)
-
         return_value, errors = ComplianceChecker.run_checker(
             ds_loc=STATIC_FILES['2dim'],
             verbose=0,
             criteria='strict',
             checker_names=['cf'],
-            output_filename=path,
+            output_filename=self.path,
             output_format='html'
         )
 
-        assert os.stat(path).st_size > 0
+        assert os.stat(self.path).st_size > 0
 
-    def test_json_output(self):
+    def test_single_json_output(self):
         '''
-        Tests that the CF checker can produce JSON output
+        Tests that a suite can produce JSON output to a file
         '''
-
-        fd, path = tempfile.mkstemp()
-        os.close(fd)
-        self.addCleanup(os.remove, path)
-
         return_value, errors = ComplianceChecker.run_checker(
             ds_loc=STATIC_FILES['conv_bad'],
             verbose=0,
             criteria='strict',
             checker_names=['cf'],
-            output_filename=path,
+            output_filename=self.path,
             output_format='json'
         )
 
-        assert os.stat(path).st_size > 0
+        assert os.stat(self.path).st_size > 0
+        with open(self.path) as f:
+            r = json.load(f)
+            assert 'cf' in r
 
-    def test_json_output(self):
+    def test_multiple_json_output(self):
+        '''
+        Tests that a suite can produce JSON output to a file
+        '''
+        return_value, errors = ComplianceChecker.run_checker(
+            ds_loc=STATIC_FILES['conv_bad'],
+            verbose=0,
+            criteria='strict',
+            checker_names=['acdd', 'cf'],
+            output_filename=self.path,
+            output_format='json'
+        )
+
+        assert os.stat(self.path).st_size > 0
+        with open(self.path) as f:
+            r = json.load(f)
+            assert 'cf' in r
+            assert 'acdd' in r
+
+    def test_multiple_json_output_stdout(self):
+        '''
+        Tests that a suite can produce JSON output to stdout
+        '''
+        saved = sys.stdout
+        try:
+            fake_stdout = io.StringIO()
+            sys.stdout = fake_stdout
+            return_value, errors = ComplianceChecker.run_checker(
+                ds_loc=STATIC_FILES['conv_bad'],
+                verbose=0,
+                criteria='strict',
+                checker_names=['acdd', 'cf'],
+                output_filename='-',
+                output_format='json'
+            )
+            r = json.loads(fake_stdout.getvalue().strip())
+            assert 'acdd' in r
+            assert 'cf' in r
+        finally:
+            sys.stdout = saved
+
+    def test_single_json_output_stdout(self):
+        '''
+        Tests that a suite can produce JSON output to stdout
+        '''
+        saved = sys.stdout
+        try:
+            fake_stdout = io.StringIO()
+            sys.stdout = fake_stdout
+            return_value, errors = ComplianceChecker.run_checker(
+                ds_loc=STATIC_FILES['conv_bad'],
+                verbose=0,
+                criteria='strict',
+                checker_names=['cf'],
+                output_filename='-',
+                output_format='json'
+            )
+            r = json.loads(fake_stdout.getvalue().strip())
+            assert 'cf' in r
+        finally:
+            sys.stdout = saved
+
+    def test_text_output(self):
         '''
         Tests that the 'text' output can be redirected to file with arguments
         to the command line
         '''
-
-        fd, path = tempfile.mkstemp()
-        os.close(fd)
-        self.addCleanup(os.remove, path)
-
         return_value, errors = ComplianceChecker.run_checker(
             ds_loc=STATIC_FILES['conv_bad'],
             verbose=0,
             criteria='strict',
-            checker_names=['cf'],
-            output_filename=path,
+            checker_names=['acdd', 'cf'],
+            output_filename=self.path,
             output_format='text'
         )
 
-        assert os.stat(path).st_size > 0
+        assert os.stat(self.path).st_size > 0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,2 @@
-pytest==2.9.0
+pytest>=2.9.0
 httpretty==0.8.14


### PR DESCRIPTION
* Changed the CheckSuite's `json_output` to a `dict_output`, making it much more useful for future output formats (when that gets revamped).
* Multiple score groups now work with the `json` output format
* Cleaned up tests (there was a duplicate test name)
* Added a test that examines `stdout` contents. This should be mimicked as needed in other output formats to test the contents of `stdout` (its not tested at all right now).