### PR TITLE
Fixes climatology variable detection and adds tests

### DIFF
--- a/compliance_checker/tests/data/climatology.cdl
+++ b/compliance_checker/tests/data/climatology.cdl
@@ -1,0 +1,22 @@
+netcdf climatology.nc {
+dimensions:
+    time=1;
+    nv=2;
+variables:
+    float temperature(time);
+        temperature:long_name = "surface air temperature";
+        temperature:cell_methods = "time: mean within days time: mean over days";
+        temperature:units = "K";
+
+    float lat;
+        lat:standard_name = "latitude";
+        lat:units = "degrees_north";
+    float lon;
+        lon:standard_name = "longitude";
+        lon:units = "degrees_east";
+    double time(time);
+        time:climatology = "climatology_bounds";
+        time:units = "hours since 1997-4-1";
+        time:standard_name = "time";
+    double climatology_bounds(time, nv);
+}

--- a/compliance_checker/tests/resources.py
+++ b/compliance_checker/tests/resources.py
@@ -66,4 +66,5 @@ STATIC_FILES = {
     'ncei_gold_point_1'                    : get_filename('tests/data/ncei_gold_point_1.cdl'),
     'ncei_gold_point_2'                    : get_filename('tests/data/ncei_gold_point_2.cdl'),
     'ghrsst'                               : get_filename('tests/data/20160919092000-ABOM-L3S_GHRSST-SSTfnd-AVHRR_D-1d_dn_truncate.cdl'),
+    'climatology'                          : get_filename('tests/data/climatology.cdl'),
 }

--- a/compliance_checker/tests/test_feature_detection.py
+++ b/compliance_checker/tests/test_feature_detection.py
@@ -168,3 +168,15 @@ class TestFeatureDetection(TestCase):
             assert 'lon_bnds' not in util.get_geophysical_variables(nc)
             assert 'lat_bnds' in util.get_cell_boundary_variables(nc)
             assert 'lon_bnds' in util.get_cell_boundary_variables(nc)
+
+    def test_climatology(self):
+        '''
+        Ensures that climatology variables are identified as climatology variables and not geophysical variables
+        '''
+        with Dataset(resources.STATIC_FILES['climatology']) as nc:
+            geophysical_variables = util.get_geophysical_variables(nc)
+            climatology_variable = util.get_climatology_variable(nc)
+            assert 'temperature' in geophysical_variables
+            assert 'climatology_bounds' not in geophysical_variables
+            assert 'climatology_bounds' == climatology_variable
+


### PR DESCRIPTION
- Detecting a climatology variable is now exactly as it is described in
  §7.4 of CF.
- There can only be one variable describing the climatology bounds in a
  CF compliant dataset.
- It's simply whatever the time variable points to with the
  `climatology` attribute.
- It is NOT a geophysical variable