### PR TITLE
Refactor check_units

### DIFF
--- a/compliance_checker/base.py
+++ b/compliance_checker/base.py
@@ -91,7 +91,15 @@ class Result(object):
     Stores the checker instance and the check method that produced this result.
     """
 
-    def __init__(self, weight=BaseCheck.MEDIUM, value=None, name=None, msgs=None, children=None, checker=None, check_method=None):
+    def __init__(self, 
+                 weight=BaseCheck.MEDIUM,
+                 value=None,
+                 name=None,
+                 msgs=None,
+                 children=None,
+                 checker=None,
+                 check_method=None,
+                 variable_name=None):
 
         self.weight = weight
 
@@ -109,6 +117,7 @@ class Result(object):
 
         self.checker = checker
         self.check_method = check_method
+        self.variable_name = variable_name
 
     def __repr__(self):
         ret = '{} (*{}): {}'.format(self.name, self.weight, self.value)
@@ -138,6 +147,33 @@ class Result(object):
 
     def __eq__(self, other):
         return self.serialize() == other.serialize()
+
+
+class TestCtx(object):
+    '''
+    Simple struct object that holds score values and messages to compile into a result
+    '''
+    def __init__(self, category=None, description='', out_of=0, score=0, messages=None, variable=None):
+        self.category = category or BaseCheck.LOW
+        self.out_of = out_of
+        self.score = score
+        self.messages = messages or []
+        self.description = description or ''
+        self.variable = variable
+
+    def to_result(self):
+        return Result(self.category, (self.score, self.out_of), self.description, self.messages, variable_name=self.variable)
+
+    def assert_true(self, test, message):
+        '''
+        Increments score if test is true otherwise appends a message
+        '''
+        self.out_of += 1
+
+        if test:
+            self.score += 1
+        else:
+            self.messages.append(message)
 
 
 def std_check_in(dataset, name, allowed_vals):

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -768,7 +768,6 @@ class CFBaseCheck(BaseCheck):
         variable = ds.variables[variable_name]
         units = getattr(variable, 'units', None)
         standard_name = getattr(variable, 'standard_name', None)
-        standard_name, standard_name_modifier = self._split_standard_name(standard_name)
 
         unitless_standard_names = cfutil.get_unitless_standard_names()
 
@@ -779,6 +778,8 @@ class CFBaseCheck(BaseCheck):
                                        "§3.1 Variable {}'s units are appropriate for "
                                        "the standard_name {}".format(variable_name,
                                                                      standard_name or "unspecified"))
+
+        standard_name, standard_name_modifier = self._split_standard_name(standard_name)
 
         standard_entry = self._std_names.get(standard_name, None)
         if standard_entry is not None:

--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -299,6 +299,15 @@ class StandardNameTable(object):
         entry = self.NameEntry(self._root.xpath('entry')[idx])
         return entry
 
+    def get(self, key, default=None):
+        '''
+        Returns the item for the key or returns the default if it does not exist
+        '''
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
     def __contains__(self, key):
         return key in self._names or key in self._aliases
 

--- a/compliance_checker/cfutil.py
+++ b/compliance_checker/cfutil.py
@@ -87,7 +87,7 @@ def is_geophysical(ds, variable):
         return False
 
     # Is it a QC Flag?
-    if 'status_flag' in standard_name:
+    if 'status_flag' in standard_name or hasattr(ncvar, 'flag_meanings'):
         return False
 
     # Is it a §7.1 Cell Boundaries variable

--- a/compliance_checker/cfutil.py
+++ b/compliance_checker/cfutil.py
@@ -168,17 +168,12 @@ def get_auxiliary_coordinate_variables(ds):
             aux_vars.append(variable)
 
     # Last are any variables that define the common coordinate standard names
-    lon = get_lon_variable(ds)
-    if lon and lon not in aux_vars:
-        aux_vars.append(lon)
+    coordinate_standard_names = ['time', 'longitude', 'latitude', 'height', 'depth', 'altitude']
 
-    lat = get_lat_variable(ds)
-    if lat and lat not in aux_vars:
-        aux_vars.append(lat)
-
-    time_var = get_time_variable(ds)
-    if time_var and time_var not in aux_vars:
-        aux_vars.append(time_var)
+    # Some datasets like ROMS use multiple variables to define coordinates
+    for ncvar in ds.get_variables_by_attributes(standard_name=lambda x: x in coordinate_standard_names):
+        if ncvar.name not in aux_vars:
+            aux_vars.append(ncvar.name)
 
     # Remove any that are purely coordinate variables
     ret_val = []

--- a/compliance_checker/tests/__init__.py
+++ b/compliance_checker/tests/__init__.py
@@ -1,0 +1,41 @@
+from netCDF4 import Dataset
+import unittest
+
+
+class BaseTestCase(unittest.TestCase):
+    '''
+    Base test case compliance checker unit tests
+    '''
+
+    def shortDescription(self):
+        return None
+
+    def __repr__(self):
+        name = self.id()
+        name = name.split('.')
+        return "%s ( %s )" % (name[-1], '.'.join(name[:-2]) + ":" + '.'.join(name[-2:]))
+    __str__ = __repr__
+
+    def load_dataset(self, nc_dataset):
+        '''
+        Return a loaded NC Dataset for the given path
+        '''
+        if not isinstance(nc_dataset, str):
+            raise ValueError("nc_dataset should be a string")
+
+        nc_dataset = Dataset(nc_dataset, 'r')
+        self.addCleanup(nc_dataset.close)
+        return nc_dataset
+
+    def assert_result_is_good(self, result):
+        if isinstance(result.value, bool):
+            assert result.value is True
+        else:
+            assert result.value[0] == result.value[1]
+
+    def assert_result_is_bad(self, result):
+        if isinstance(result.value, bool):
+            assert result.value is False
+        else:
+            assert result.value[0] != result.value[1]
+

--- a/compliance_checker/tests/data/bad_units.cdl
+++ b/compliance_checker/tests/data/bad_units.cdl
@@ -1,0 +1,21 @@
+netcdf bad_units {
+dimensions:
+    time = 2;
+variables:
+    double time(time);
+        time:standard_name = "time";
+        time:units = "s"; // wrong, should be <unit> since <epoch>
+    double lat;
+        lat:standard_name = "latitude";
+        lat:units = "degrees_E"; // ok but not preferred
+    double lon;
+        lon:standard_name = "longitude";
+        lon:units = "degrees"; // actually allowed on a transformed grid
+    double lev;
+        lev:long_name = "Level";
+        lev:units = "level"; //deprecated
+    double temp(time);
+        temp:standard_name = "atmospheric_temperature";
+        temp:units = "N"; // valid udunits but not appropriate for temperature
+        temp:coordinates = "time lon lat";
+}

--- a/compliance_checker/tests/data/bad_units.cdl
+++ b/compliance_checker/tests/data/bad_units.cdl
@@ -18,4 +18,8 @@ variables:
         temp:standard_name = "atmospheric_temperature";
         temp:units = "N"; // valid udunits but not appropriate for temperature
         temp:coordinates = "time lon lat";
+    int temp_count(time);
+        temp_count:standard_name = "atmospheric_temperature number_of_observations";
+        temp_count:units = "1";
+        temp_count:coordinates = "time lon lat";
 }

--- a/compliance_checker/tests/data/rotated_pole_grid.cdl
+++ b/compliance_checker/tests/data/rotated_pole_grid.cdl
@@ -1,3 +1,4 @@
+// Example 5.2 from CF 1.6
 netcdf rotated_pole_grid {
 dimensions:
     rlon = 2;

--- a/compliance_checker/tests/resources.py
+++ b/compliance_checker/tests/resources.py
@@ -68,4 +68,5 @@ STATIC_FILES = {
     'ghrsst'                               : get_filename('tests/data/20160919092000-ABOM-L3S_GHRSST-SSTfnd-AVHRR_D-1d_dn_truncate.cdl'),
     'climatology'                          : get_filename('tests/data/climatology.cdl'),
     'rotated_pole_grid'                    : get_filename('tests/data/rotated_pole_grid.cdl'),
+    'bad_units'                            : get_filename('tests/data/bad_units.cdl'),
 }

--- a/compliance_checker/tests/test_acdd.py
+++ b/compliance_checker/tests/test_acdd.py
@@ -1,6 +1,6 @@
-import unittest
 from compliance_checker.acdd import ACDD1_1Check, ACDD1_3Check
 from compliance_checker.tests.resources import STATIC_FILES
+from compliance_checker.tests import BaseTestCase
 from netCDF4 import Dataset
 import os
 
@@ -24,34 +24,6 @@ def check_varset_nonintersect(group0, group1):
     '''
     # Performs symmetric difference on two lists converted to sets
     return len(set(group0) ^ set(group1)) == 0
-
-
-class BaseTestCase(unittest.TestCase):
-    '''
-    Base test case for ACDD
-    '''
-    def load_dataset(self, nc_dataset):
-        '''
-        Return a loaded NC Dataset for the given path
-        '''
-        if not isinstance(nc_dataset, str):
-            raise ValueError("nc_dataset should be a string")
-
-        nc_dataset = Dataset(nc_dataset, 'r')
-        self.addCleanup(nc_dataset.close)
-        return nc_dataset
-
-    def assert_result_is_good(self, result):
-        if isinstance(result.value, bool):
-            assert result.value is True
-        else:
-            assert result.value[0] == result.value[1]
-
-    def assert_result_is_bad(self, result):
-        if isinstance(result.value, bool):
-            assert result.value is False
-        else:
-            assert result.value[0] != result.value[1]
 
 
 class TestACDD1_1(BaseTestCase):

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -326,6 +326,13 @@ class TestCF(BaseTestCase):
         assert result.value == (2, 3)
         assert 'units for lev, "level" are deprecated by CF 1.6' in result.msgs
 
+        # temp_count(time);
+        #   temp_count:standard_name = "atmospheric_temperature number_of_observations";
+        #   temp_count:units = "1";
+        result = result_dict[u"§3.1 Variable temp_count's units are appropriate for "
+                             u"the standard_name atmospheric_temperature number_of_observations"]
+        assert result.value == (1, 1)
+
     def test_coordinate_types(self):
         '''
         Section 4 Coordinate Types

--- a/compliance_checker/tests/test_feature_detection.py
+++ b/compliance_checker/tests/test_feature_detection.py
@@ -199,4 +199,13 @@ class TestFeatureDetection(TestCase):
             assert 'lat' == util.get_lat_variable(nc)
             assert 'lon' == util.get_lon_variable(nc)
 
+    def test_auxiliary_coordinates(self):
+        '''
+        Ensures variables are classified as auxiliary coordinate variables
+        '''
+        with Dataset(resources.STATIC_FILES['bad_units']) as nc:
+            coordinate_variables = util.get_coordinate_variables(nc)
+            assert set(['time']) == set(coordinate_variables)
 
+            aux_coord_vards = util.get_auxiliary_coordinate_variables(nc)
+            assert set(['lat', 'lon']) == set(aux_coord_vards)


### PR DESCRIPTION
- Replaces `_find_data_vars` with `_find_geophysical_variables`
- Refactors `check_units` to correctly validate units according to section 3 of CF 1.6
- Splits the complicated logic of `check_units` into three functions
- Adds more detailed unit tests to check assertions of failure and success