### PR TITLE
Refactors check_standard_name

### DIFF
--- a/compliance_checker/cfutil.py
+++ b/compliance_checker/cfutil.py
@@ -371,6 +371,20 @@ def get_climatology_variable(ds):
     return None
 
 
+def get_flag_variables(ds):
+    '''
+    Returns a list of variables that are defined as flag variables
+    '''
+    flag_variables = []
+    for name, ncvar in ds.variables.items():
+        standard_name = getattr(ncvar, 'standard_name', None)
+        if isinstance(standard_name, basestring) and 'status_flag' in standard_name:
+            flag_variables.append(name)
+        if hasattr(ncvar, 'flag_meanings'):
+            flag_variables.append(name)
+    return flag_variables
+
+
 def get_grid_mapping_variables(ds):
     '''
     Returns a list of grid mapping variables

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -229,9 +229,24 @@ class TestCF(BaseTestCase):
             self.assertTrue(each.value)
 
         dataset = self.load_dataset(STATIC_FILES['bad_data_type'])
-        result = self.cf.check_standard_name(dataset)
-        for each in result:
-            self.assertFalse(each.value)
+        results = self.cf.check_standard_name(dataset)
+        result_dict = {result.name: result for result in results}
+        result = result_dict[u'§3.3 Variable time has valid standard_name attribute']
+        assert result.value == (0, 2)
+        assert 'standard_name undefined is not defined' in result.msgs[1]
+
+        result = result_dict[u'§3.3 Variable latitude has valid standard_name attribute']
+        assert result.value == (0, 2)
+        assert 'standard_name undefined is not defined' in result.msgs[1]
+
+        result = result_dict[u'§3.3 Variable salinity has valid standard_name attribute']
+        assert result.value == (1, 2)
+        assert 'standard_name Chadwick is not defined in Standard Name Table' in result.msgs[0]
+
+        result = result_dict[u'§3.3 standard_name modifier for salinity is valid']
+        assert result.value == (0, 1)
+
+        assert len(result_dict) == 7
 
     def test_download_standard_name_table(self):
         """


### PR DESCRIPTION
- Refactor check_standard_name
  - Change the set of variables being checked
  - If a variable defines long_name standard_name check is optional
  - Include standard name table in version
  - Check standard_name modifiers

- Adds get_flag_variables to cfutil