### PR TITLE
Adds test for duplicate variable names

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -463,8 +463,8 @@ class CFBaseCheck(BaseCheck):
         for k in ds.variables:
             names[k.lower()] += 1
 
-        fails = ['Variables are not case sensitive.  Duplicate variables named: %s' % k for k, v in names.items() if v > 1]
-        return Result(BaseCheck.LOW, (total - len(fails), total), '§2.3 Unique variable names', msgs=fails)
+        fails = ['Variables are not case sensitive. Duplicate variables named: %s' % k for k, v in names.items() if v > 1]
+        return Result(BaseCheck.MEDIUM, (total - len(fails), total), '§2.3 Unique variable names', msgs=fails)
 
     def check_dimension_names(self, ds):
         '''

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -149,7 +149,10 @@ class TestCF(BaseTestCase):
 
         self.assertEqual(result.value, expected)
 
-        # TODO: Add bad unique names to bad.nc
+        dataset = self.load_dataset(STATIC_FILES['chap2'])
+        result = self.cf.check_names_unique(dataset)
+        assert result.value == (6, 7)
+        assert result.msgs[0] == 'Variables are not case sensitive. Duplicate variables named: not_unique'
 
     def test_check_dimension_names(self):
         """


### PR DESCRIPTION
CF §2.3 

> ... it is _recommended_ that names should not be distinguished purely by case

I changed the priority to medium, since the language uses "recommended," and not "suggest" or "optional".