### PR TITLE
Removes deprecated check on scalar coordinates

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -2268,44 +2268,6 @@ class CFBaseCheck(BaseCheck):
 
         return ret_val
 
-    def check_scalar_coordinate_system(self, ds):
-        """
-        5.7 When a variable has an associated coordinate which is single-valued, that coordinate may be represented as a
-        scalar variable. Since there is no associated dimension these scalar coordinate variables should be attached to a
-        data variable via the coordinates attribute.
-
-        Once a name is used for a scalar coordinate variable it can not be used for a 1D coordinate variable. For this
-        reason we strongly recommend against using a name for a scalar coordinate variable that matches the name of any
-        dimension in the file.
-        """
-        ret_val = []
-
-        for name, var in ds.variables.items():
-            valid_scalar_coordinate_var = 0
-            total_scalar_coordinate_var = 0
-            reasoning = []
-
-            if not hasattr(var, 'coordinates'):
-                continue
-
-            for coordinate in getattr(var, 'coordinates', '').split(" "):
-                if coordinate in ds.variables:
-                    if ds.variables[coordinate].shape == ():
-                        total_scalar_coordinate_var += 1
-                        if coordinate not in list(ds.dimensions.keys()):
-                            valid_scalar_coordinate_var += 1
-                        else:
-                            reasoning.append('Scalar coordinate var (%s) of var (%s) is correct size but is present in the dimensions list, which is not allowed.' % (coordinate, name))
-
-            if total_scalar_coordinate_var > 0:
-                result = Result(BaseCheck.MEDIUM,
-                                (valid_scalar_coordinate_var, total_scalar_coordinate_var),
-                                ('§5.7 Scalar coordinate variables', name, 'scalar_coordinates'),
-                                reasoning)
-                ret_val.append(result)
-
-        return ret_val
-
     ###############################################################################
     #
     # Chapter 6: Labels and Alternative Coordinates

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -813,18 +813,6 @@ class TestCF(BaseTestCase):
         result = result_dict[u'§5.6 Variable lat defining a grid mapping has valid grid_mapping attribute']
         assert result.value == (2, 2)
 
-    def test_check_scalar_coordinate_system(self):
-        dataset = self.load_dataset(STATIC_FILES['scalar_coordinate_variable'])
-        results = self.cf.check_scalar_coordinate_system(dataset)
-        self.assertEqual(len(results), 2)
-        for r in results:
-            if r.name[1] == 'HEIGHT':
-                self.assertEqual(r.value, (0, 1))
-            elif r.name[1] == 'DEPTH':
-                self.assertEqual(r.value, (2, 2))
-            else:
-                self.assertTrue(False, 'Unexpected variable in results of check_scalar_coordinate_system')
-
     def test_check_geographic_region(self):
         dataset = self.load_dataset(STATIC_FILES['bad_region'])
         results = self.cf.check_geographic_region(dataset)


### PR DESCRIPTION
- Scalar coordinates are now being checked just like all the other
  coordinates and they are inherently associated with variables through
  the `coordinates` attribute.