### PR TITLE
Fixes assumption about coordinates

### DIFF
--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -838,7 +838,7 @@ class TestCF(BaseTestCase):
         results = self.cf.check_instance_variables(dataset)
 
         result_dict = {result.name: result for result in results}
-        result = result_dict[u'§9.5 Instance Variable station_name is not referenced as a coordinate variable']
+        result = result_dict[u'§9.5 Instance Variable station_name should not be referenced as a coordinate variable']
         assert result.value == (0, 1)
 
     def test_check_all_features_are_same_type(self):


### PR DESCRIPTION
- Updates label in test

My assumption up until this point was that coordinate types where
physical data representing a coordinate of the variable. This is
supported in every chapter right up until chapter 6. §6.1, Labels,
throws a huge wrench into this assumption.

Chapter 6 allows for auxiliary coordinates to be labels, like regions or
station names or whatever. It was my assumption, until I reread it, that
labels just shared dimensions with features, not were directly related
through coordinates.

I personally disagree with this, labels aren't conceptually coordinates
they would be better suited as ancillary data. They don't define where,
or when in the physical world or a mapped coordinate system.

In any case this refactor corrects my incorrect assumption.