### PR TITLE
Implements 8.2, "Compression by gathering"

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -2851,12 +2851,12 @@ class CFBaseCheck(BaseCheck):
             # puts the referenced variable being compressed into a set
             compress_set = set(compress_var.compress.split(' '))
             if compress_var.ndim != 1:
-                valid=False
+                valid = False
                 reasoning.append("Compression variable {} may only have one dimension".format(compress_var.name))
             # ensure compression variable is a proper index, and thus is an
             # signed or unsigned integer type of some sort
             if compress_var.dtype.kind not in {'i', 'u'}:
-                valid=False
+                valid = False
                 reasoning.append("Compression variable {} must be an integer type to form a proper array index".format(compress_var.name))
             # make sure all the variables referred to are contained by the
             # variables.

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -830,6 +830,19 @@ class TestCF(BaseTestCase):
         self.assertTrue(results[2].value)
         self.assertFalse(results[3].value)
 
+    def test_compress_packed(self):
+        """Tests compressed indexed coordinates"""
+        dataset = self.load_dataset(STATIC_FILES['reduced_horizontal_grid'])
+        results = self.cf.check_compression_gathering(dataset)
+        self.assertTrue(results[0].value)
+
+        dataset = self.load_dataset(STATIC_FILES['bad_data_type'])
+        results = self.cf.check_compression_gathering(dataset)
+        self.assertFalse(results[0].value)
+        self.assertFalse(results[1].value)
+
+
+
     def test_check_instance_variable(self):
         dataset = self.load_dataset(STATIC_FILES['bad-instance'])
         results = self.cf.check_instance_variables(dataset)


### PR DESCRIPTION
Implements section 8.2 of the CF manual, "Compression by
gathering"/issue #394 on GitHub.

Checks that compression variable containing compress attribute has
exactly one dimension, the compression variable is of integer type, and
the referenced dimensions from the blank-separated 'compress' attribute
exist within the NetCDF dataset.