### PR TITLE
Skips coordinate order checks for climatology and cell bounds variables

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -505,8 +505,16 @@ class CFBaseCheck(BaseCheck):
             if dimension not in coord_axis_map:
                 coord_axis_map[dimension] = 'U'
 
-        # Check each variable's dimension order
+        # Check each variable's dimension order, excluding climatology and
+        # bounds variables
+        any_clim = cfutil.get_climatology_variable(ds)
+        any_bounds = cfutil.get_cell_boundary_variables(ds)
         for name, variable in ds.variables.items():
+            # Skip bounds/climatology variables, as they should implicitly
+            # have the same order except for the bounds specific dimension.
+            # This is tested later in the respective checks
+            if name in any_bounds or name == any_clim:
+                continue
             if variable.dimensions:
                 dimension_order = self._get_dimension_order(ds, name, coord_axis_map)
                 valid_dimension_order.assert_true(self._dims_in_order(dimension_order),

--- a/compliance_checker/tests/data/grid-boundaries.cdl
+++ b/compliance_checker/tests/data/grid-boundaries.cdl
@@ -17,7 +17,6 @@ variables:
         lat:long_name = "Latitude";
         lat:bounds = "lat_bnds";
     float lat_bnds(lat, nv);
-        lat_bnds:units = "degrees_north";
         lat_bnds:long_name = "Latitude Cell Boundaries";
     float lon(lon);
         lon:standard_name = "longitude";
@@ -26,7 +25,6 @@ variables:
         lon:long_name = "Longitude";
         lon:bounds = "lon_bnds";
     float lon_bnds(lon, nv);
-        lon_bnds:units = "degrees_east";
         lon_bnds:long_name = "Longitude Cell Boundaries";
     float z;
         z:standard_name = "depth";

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -177,10 +177,8 @@ class TestCF(BaseTestCase):
         """
         dataset = self.load_dataset(STATIC_FILES['bad_data_type'])
         result = self.cf.check_dimension_order(dataset)
-        assert result.value == (5, 7)
-        assert result.msgs[0] == ("salinity's dimensions are not in the recommended order "
-                                  "T, Z, Y, X. They are latitude, longitude, time")
-        assert result.msgs[1] == ("really_bad's dimensions are not in the recommended order "
+        assert result.value == (5, 6)
+        assert result.msgs[0] == ("really_bad's dimensions are not in the recommended order "
                                   "T, Z, Y, X. They are latitude, power")
 
     def test_check_fill_value_outside_valid_range(self):


### PR DESCRIPTION
Skips dimension order checks for climatology and cell bounds variables.  Still
checks the parent variables, but it is unnecessary to check the former
variables as they already have their own set of checks which make the
generalized dimensional checks somewhat redundant.  Additionally, the
generalized checks were leading to erroneous bad results.  Should
address #325.