### PR TITLE
Check for float without relying on np.float128

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,28 +2,41 @@ language: python
 
 sudo: false
 
-env:
-    - CONDA="python=2.7"
-    - CONDA="python=3.4"
-    - CONDA="python=3.5"
+matrix:
+  fast_finish: true
+  include:
+  - python: 2.7
+    env: TEST_TARGET=default
+  - python: 3.4
+    env: TEST_TARGET=default
+  - python: 3.5
+    env: TEST_TARGET=default
+  - python: 3.6
+    env: TEST_TARGET=default
+  - python: 3.6
+    env: TEST_TARGET=coding_standards
+  allow_failures:
+  - python: 3.6
+    env: TEST_TARGET=coding_standards
 
 before_install:
-    - URL=http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
-    - wget $URL -O miniconda.sh
+    - wget http://bit.ly/miniconda -O miniconda.sh
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
-    - conda update --yes --all
+    - conda update conda --yes
     - conda config --add channels conda-forge --force
-    - travis_retry conda create --yes -n test --file requirements.txt $CONDA
-    - travis_retry conda install -n test --yes pytest flake8
-    - travis_retry conda install -n test --yes libxml2==2.9.3
-    - source activate test
+    - conda create --yes -n TEST python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file test_requirements.txt
+    - source activate TEST
 
+# Test source distribution.
 install:
-    - pip install -r requirements.txt
-    - pip install -r test_requirements.txt
-    - pip install -e .
+    - python setup.py sdist && version=$(python setup.py --version) && pushd dist  && pip install compliance-checker-${version}.tar.gz && popd
 
 script:
-    - py.test -s -rxs -v
-    - flake8 --ignore=E501,E251,E221,E201,E202,E203 -qq --statistics . || true
+  - if [[ $TEST_TARGET == "default" ]]; then
+      py.test -s -rxs -v ;
+    fi
+
+  - if [[ $TEST_TARGET == "coding_standards" ]]; then
+      flake8 --ignore=E501,E251,E221,E201,E202,E203 -qq --statistics . ;
+    fi

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -2894,7 +2894,7 @@ class CFBaseCheck(BaseCheck):
                 reasoning.append("Attributes add_offset and scale_factor have different data type.")
             elif type(scale_factor) != var.dtype:
                 # Check both attributes are type float or double
-                if not type(scale_factor) in [np.float, np.float16, np.float32, np.float64, np.float128]:
+                if not isinstance(scale_factor, (float, np.floating)):
                     valid = False
                     reasoning.append("Attributes add_offset and scale_factor are not of type float or double.")
                 else:

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,3 @@
+flake8
 pytest>=2.9.0
 httpretty==0.8.14


### PR DESCRIPTION
@lukecampbell it seems that @jbosch-noaa cannot use `np.float128` on some Windows machines.

This PR changes the logic to check if `scale_factor` is the primitive `float` or `np.floating` (which means any of those in the list there.)

PS: I incorporated #479 so we can run the tests.