### PR TITLE
Remove python-dateutil and workaround httpretty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,16 @@ matrix:
     env: TEST_TARGET=coding_standards
 
 before_install:
-    - wget http://bit.ly/miniconda -O miniconda.sh
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
-    - conda update conda --yes
-    - conda config --add channels conda-forge --force
-    - conda create --yes -n TEST python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file test_requirements.txt
-    - source activate TEST
+  - wget http://bit.ly/miniconda -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda update conda --yes
+  - conda config --add channels conda-forge --force
+  - conda create --yes -n TEST python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file test_requirements.txt
+  - source activate TEST
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      conda install --yes httpretty ;
+    fi
 
 # Test source distribution.
 install:

--- a/compliance_checker/tests/test_ioos.py
+++ b/compliance_checker/tests/test_ioos.py
@@ -1,51 +1,58 @@
 import unittest
 from compliance_checker.suite import CheckSuite
 from compliance_checker.runner import ComplianceChecker
-import httpretty
 import os
+import sys
+
+if sys.version_info < (3,0):
+    import httpretty
+else:
+    httpretty = False
 
 # TODO: Use inheritance to eliminate redundant code in test setup, etc
+if httpretty:
+    class TestIOOSSOSGetCapabilities(unittest.TestCase):
 
-class TestIOOSSOSGetCapabilities(unittest.TestCase):
+        def setUp(self):
+            with open(os.path.join(os.path.dirname(__file__),
+                        'data/http_mocks/ncsos_getcapabilities.xml')) as f:
+                self.resp = f.read()
+            # need to monkey patch checkers prior to running tests, or no checker
+            # classes will show up
+            CheckSuite().load_all_available_checkers()
 
-    def setUp(self):
-        with open(os.path.join(os.path.dirname(__file__),
-                       'data/http_mocks/ncsos_getcapabilities.xml')) as f:
-            self.resp = f.read()
-        # need to monkey patch checkers prior to running tests, or no checker
-        # classes will show up
-        CheckSuite().load_all_available_checkers()
 
-    @httpretty.activate
-    def test_retrieve_getcaps(self):
-        """Method that simulates retrieving SOS GetCapabilities"""
-        url = "http://data.oceansmap.com/thredds/sos/caricoos_ag/VIA/VIA.ncml"
-        httpretty.register_uri(httpretty.GET, url, body=self.resp)
-        # need to mock out the HEAD response so that compliance checker
-        # recognizes this as some sort of XML doc instead of an OPeNDAP
-        # source
-        httpretty.register_uri(httpretty.HEAD, url, status=200,
-                                content_type='text/xml')
-        ComplianceChecker.run_checker(url, ['ioos'], 1, 'normal')
+        @httpretty.activate
+        def test_retrieve_getcaps(self):
+            """Method that simulates retrieving SOS GetCapabilities"""
+            url = "http://data.oceansmap.com/thredds/sos/caricoos_ag/VIA/VIA.ncml"
+            httpretty.register_uri(httpretty.GET, url, body=self.resp)
+            # need to mock out the HEAD response so that compliance checker
+            # recognizes this as some sort of XML doc instead of an OPeNDAP
+            # source
+            httpretty.register_uri(httpretty.HEAD, url, status=200,
+                                    content_type='text/xml')
+            ComplianceChecker.run_checker(url, ['ioos'], 1, 'normal')
 
-class TestIOOSSOSDescribeSensor(unittest.TestCase):
+    class TestIOOSSOSDescribeSensor(unittest.TestCase):
 
-    def setUp(self):
-        with open(os.path.join(os.path.dirname(__file__),
-                       'data/http_mocks/ncsos_describesensor.xml')) as f:
-            self.resp = f.read()
-        # need to monkey patch checkers prior to running tests, or no checker
-        # classes will show up
-        CheckSuite().load_all_available_checkers()
+        def setUp(self):
+            with open(os.path.join(os.path.dirname(__file__),
+                        'data/http_mocks/ncsos_describesensor.xml')) as f:
+                self.resp = f.read()
+            # need to monkey patch checkers prior to running tests, or no checker
+            # classes will show up
+            CheckSuite().load_all_available_checkers()
 
-    @httpretty.activate
-    def test_retrieve_describesensor(self):
-        """Method that simulates retrieving SOS DescribeSensor"""
-        url = "http://data.oceansmap.com/thredds/sos/caricoos_ag/VIA/VIA.ncml?request=describesensor&service=sos&procedure=urn:ioos:station:ncsos:VIA&outputFormat=text/xml%3Bsubtype%3D%22sensorML/1.0.1/profiles/ioos_sos/1.0%22&version=1.0.0"
-        httpretty.register_uri(httpretty.GET, url, body=self.resp)
-        # need to mock out the HEAD response so that compliance checker
-        # recognizes this as some sort of XML doc instead of an OPeNDAP
-        # source
-        httpretty.register_uri(httpretty.HEAD, url, status=200,
-                                content_type='text/xml')
-        ComplianceChecker.run_checker(url, ['ioos'], 1, 'normal')
+
+        @httpretty.activate
+        def test_retrieve_describesensor(self):
+            """Method that simulates retrieving SOS DescribeSensor"""
+            url = "http://data.oceansmap.com/thredds/sos/caricoos_ag/VIA/VIA.ncml?request=describesensor&service=sos&procedure=urn:ioos:station:ncsos:VIA&outputFormat=text/xml%3Bsubtype%3D%22sensorML/1.0.1/profiles/ioos_sos/1.0%22&version=1.0.0"
+            httpretty.register_uri(httpretty.GET, url, body=self.resp)
+            # need to mock out the HEAD response so that compliance checker
+            # recognizes this as some sort of XML doc instead of an OPeNDAP
+            # source
+            httpretty.register_uri(httpretty.HEAD, url, status=200,
+                                    content_type='text/xml')
+            ComplianceChecker.run_checker(url, ['ioos'], 1, 'normal')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ OWSLib>=0.8.3
 lxml>=3.2.1
 cf_units>=0.1.1
 requests>=2.2.1
-python-dateutil>=2.2
 isodate==0.5.4
 Jinja2>=2.7.3
 setuptools>=15.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,2 @@
 flake8
 pytest>=2.9.0
-httpretty==0.8.14


### PR DESCRIPTION
`httpretty` is not Python 3 compliant and the packages in `defaults` should be used with care (`conda-forge`) does not package them BTW. (See https://github.com/gabrielfalcao/HTTPretty#disclaimer)

However the problem was being masked because the tests where running on Python 2.7 only due to a weird bug: the presence of `python-datetutil` in the requirements list. (Check the previous logs and [this](https://travis-ci.org/ocefpaf/compliance-checker/builds/220922447) without `python-datetutil`.)

So this PR removes `python-datetutil`, to enable Python 3 tests, and works around the lack of `httpretty` in `test_ioos.py`.