### PR TITLE
Windows tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # IOOS Compliance Checker
 
 [![Build Status](https://travis-ci.org/ioos/compliance-checker.svg)](https://travis-ci.org/ioos/compliance-checker)
+[![Build status](https://ci.appveyor.com/api/projects/status/lcc9co38pi6o45ho/branch/master?svg=true)](https://ci.appveyor.com/project/ocefpaf/compliance-checker/branch/master)
 
 The IOOS Compliance Checker is a Python tool to check local/remote datasets against a variety of compliance standards.
 It is primarily a command-line tool (tested on OS X/Linux) and can also be used as a library import.
@@ -78,13 +79,13 @@ $ compliance-checker --test=acdd compliance_checker/tests/data/ru07-20130824T170
 
 
 --------------------------------------------------------------------------------
-                     The dataset scored 69 out of 93 points                     
-                             during the acdd check                              
+                     The dataset scored 69 out of 93 points
+                             during the acdd check
 --------------------------------------------------------------------------------
-                               Scoring Breakdown:                               
+                               Scoring Breakdown:
 
 
-                                 High Priority                                  
+                                 High Priority
 --------------------------------------------------------------------------------
     Name                            :Priority: Score
 Conventions                             :3:     1/2
@@ -94,7 +95,7 @@ title                                   :3:     1/1
 varattr                                 :3:    32/44
 
 
-                                Medium Priority                                 
+                                Medium Priority
 --------------------------------------------------------------------------------
     Name                            :Priority: Score
 acknowledgment/acknowledgement          :2:     1/1
@@ -141,44 +142,44 @@ time_coverage_start                     :2:     1/1
 
 
 --------------------------------------------------------------------------------
-                  Reasoning for the failed tests given below:                   
+                  Reasoning for the failed tests given below:
 
 
 Name                             Priority:     Score:Reasoning
 --------------------------------------------------------------------------------
 Conventions                            :3:     1/ 2 : Attr Conventions does not
                                                       contain 'ACDD-1.3'
-varattr                                :3:    32/44 :  
-    conductivity                       :3:     3/ 4 :  
+varattr                                :3:    32/44 :
+    conductivity                       :3:     3/ 4 :
         coverage_content_type          :3:     0/ 1 : Var conductivity missing
                                                       attr coverage_content_type
-    density                            :3:     3/ 4 :  
+    density                            :3:     3/ 4 :
         coverage_content_type          :3:     0/ 1 : Var density missing attr
                                                       coverage_content_type
-    profile_id                         :3:     1/ 4 :  
+    profile_id                         :3:     1/ 4 :
         coverage_content_type          :3:     0/ 1 : Var profile_id missing
                                                       attr coverage_content_type
         var_std_name                   :3:     1/ 2 : Var profile_id missing
                                                       attr standard_name
         var_units                      :3:     0/ 1 : Var profile_id missing
                                                       attr units
-    salinity                           :3:     3/ 4 :  
+    salinity                           :3:     3/ 4 :
         coverage_content_type          :3:     0/ 1 : Var salinity missing attr
                                                       coverage_content_type
-    segment_id                         :3:     1/ 4 :  
+    segment_id                         :3:     1/ 4 :
         coverage_content_type          :3:     0/ 1 : Var segment_id missing
                                                       attr coverage_content_type
         var_std_name                   :3:     1/ 2 : Var segment_id missing
                                                       attr standard_name
         var_units                      :3:     0/ 1 : Var segment_id missing
                                                       attr units
-    temperature                        :3:     3/ 4 :  
+    temperature                        :3:     3/ 4 :
         coverage_content_type          :3:     0/ 1 : Var temperature missing
                                                       attr coverage_content_type
-    u                                  :3:     3/ 4 :  
+    u                                  :3:     3/ 4 :
         coverage_content_type          :3:     0/ 1 : Var u missing attr
                                                       coverage_content_type
-    v                                  :3:     3/ 4 :  
+    v                                  :3:     3/ 4 :
         coverage_content_type          :3:     0/ 1 : Var v missing attr
                                                       coverage_content_type
 date_created_is_iso                    :2:     0/ 1 : Datetime provided is not
@@ -257,13 +258,13 @@ $ compliance-checker --test=cf compliance_checker/tests/data/examples/hycom_glob
 
 
 --------------------------------------------------------------------------------
-                    The dataset scored 113 out of 122 points                    
-                              during the cf check                               
+                    The dataset scored 113 out of 122 points
+                              during the cf check
 --------------------------------------------------------------------------------
-                               Scoring Breakdown:                               
+                               Scoring Breakdown:
 
 
-                                 High Priority                                  
+                                 High Priority
 --------------------------------------------------------------------------------
     Name                            :Priority: Score
 §2.2 Valid netCDF data types            :3:     6/6
@@ -290,7 +291,7 @@ $ compliance-checker --test=cf compliance_checker/tests/data/examples/hycom_glob
 §9.1 Feature Types are all the same     :3:     1/1
 
 
-                                Medium Priority                                 
+                                Medium Priority
 --------------------------------------------------------------------------------
     Name                            :Priority: Score
 cell_methods                            :2:     0/0
@@ -316,7 +317,7 @@ cell_methods                            :2:     0/0
 
 
 --------------------------------------------------------------------------------
-                  Reasoning for the failed tests given below:                   
+                  Reasoning for the failed tests given below:
 
 
 Name                             Priority:     Score:Reasoning

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,48 @@
+environment:
+  matrix:
+    - TARGET_ARCH: x86
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
+
+platform:
+    - x64
+
+install:
+    # If there is a newer build queued for the same PR, cancel this one.
+    # The AppVeyor 'rollout builds' option is supposed to serve the same
+    # purpose but it is problematic because it tends to cancel builds pushed
+    # directly to master instead of just PR builds (or the converse).
+    - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+         https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+           throw "There are newer queued builds for this pull request, failing early." }
+
+    # Add path, activate `conda` and update conda.
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda update --yes --quiet conda
+    - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+
+    - cmd: set PYTHONUNBUFFERED=1
+
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
+    - cmd: conda install --yes conda-build
+    - cmd: conda info
+
+# Skip .NET project specific build phase.
+build: off
+
+test_script:
+    - "conda build conda.recipe"

--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -1,3 +1,4 @@
+import io
 import itertools
 import requests
 import os
@@ -261,7 +262,7 @@ class StandardNameTable(object):
     def __init__(self, cached_location=None):
         if cached_location:
             try:
-                with open(cached_location, 'r') as fp:
+                with io.open(cached_location, 'r', encoding='utf-8') as fp:
                     resource_text = fp.read()
             except Exception:
                 resource_text = get_data("compliance_checker", "data/cf-standard-name-table.xml")

--- a/compliance_checker/tests/test_cli.py
+++ b/compliance_checker/tests/test_cli.py
@@ -23,10 +23,11 @@ class TestCLI(TestCase):
     '''
 
     def setUp(self):
-        _, self.path = tempfile.mkstemp()
+        self.fid, self.path = tempfile.mkstemp()
 
     def tearDown(self):
         if os.path.isfile(self.path):
+            os.close(self.fid)
             os.remove(self.path)
 
     def shortDescription(self):

--- a/compliance_checker/tests/test_suite.py
+++ b/compliance_checker/tests/test_suite.py
@@ -114,6 +114,7 @@ class TestSuite(unittest.TestCase):
             score_list, cdl_points, cdl_out_of = cs.standard_output(limit, checker, groups)
             # This asserts that print is able to generate all of the unicode output
             cs.non_verbose_output_generation(score_list, groups, limit, cdl_points, cdl_out_of)
+        ds.close()
 
         # Ok now load the nc file that it came from
         ds = cs.load_dataset(static_files['test_cdl_nc'])
@@ -125,6 +126,7 @@ class TestSuite(unittest.TestCase):
             score_list, nc_points, nc_out_of = cs.standard_output(limit, checker, groups)
             # This asserts that print is able to generate all of the unicode output
             cs.non_verbose_output_generation(score_list, groups, limit, nc_points, nc_out_of)
+        ds.close()
 
         nc_file_path = static_files['test_cdl'].replace('.cdl', '.nc')
         self.addCleanup(os.remove, nc_file_path)

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,41 @@
+package:
+  name: compliance-checker
+  version: 3.0.1
+
+source:
+  path: ../
+
+build:
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  entry_points:
+    - compliance-checker = cchecker:main
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - setuptools
+    - arrow
+    - cf_units
+    - isodate
+    - jinja2
+    - lxml
+    - owslib
+    - pygeoif
+    - requests
+
+test:
+  source_files:
+    - compliance_checker
+  requires:
+    - pytest
+    - httpretty  # [not py3k]
+  imports:
+    - compliance_checker
+    - compliance_checker.cf
+    - compliance_checker.tests
+  commands:
+    - py.test -s -rxs -v compliance_checker
+    - compliance-checker --help


### PR DESCRIPTION
In this PR:

- build the `conda-recipe` on Windows as a packaging test;
- enable Windows testing to avoid regression like #480;
- properly close files in the test framework to make them pass on  Windows.

Note that I enabled Windows test using my own account. Different from Travis-CI, where the members have access to the configuration and that is tied to the repo, with AppVeyor the configuration is tied to the user :unamused: 

Someone inside IOOS should take charge of that to avoid problems in the future.