### PR TITLE
Fix lints

### DIFF
--- a/cchecker.py
+++ b/cchecker.py
@@ -80,5 +80,6 @@ def main():
         return 0
     return 1
 
+
 if __name__ == "__main__":
     sys.exit(main())

--- a/compliance_checker/acdd.py
+++ b/compliance_checker/acdd.py
@@ -8,13 +8,12 @@ project for the verification and scoring of attributes for datasets.
 from __future__ import unicode_literals
 
 import numpy as np
-import numpy.ma as ma
 from netCDF4 import num2date
 from datetime import timedelta
 
 from compliance_checker.base import (BaseCheck, BaseNCCheck, check_has,
                                      score_group, Result, ratable_result)
-from compliance_checker.cf.util import is_vertical_coordinate, _possiblexunits, _possibleyunits
+from compliance_checker.cf.util import _possiblexunits, _possibleyunits
 from compliance_checker.util import datetime_is_iso, dateparse
 from compliance_checker import cfutil
 from pygeoif import from_wkt
@@ -701,4 +700,3 @@ class ACDD1_3Check(ACDDNCCheck):
                             % (variable, sorted(valid_ctypes)))
 
         return results
-

--- a/compliance_checker/base.py
+++ b/compliance_checker/base.py
@@ -13,7 +13,6 @@ from owslib.swe.observation.sos100 import SensorObservationService_1_0_0
 from owslib.swe.sensor.sml import SensorML
 from owslib.namespaces import Namespaces
 from compliance_checker import __version__
-from distutils.version import StrictVersion as V
 from lxml import etree
 import sys
 
@@ -108,7 +107,7 @@ class Result(object):
         if value is None:
             self.value = None
         elif isinstance(value, tuple):
-            assert len(value)==2, 'Result value must be 2-tuple or boolean!'
+            assert len(value) == 2, 'Result value must be 2-tuple or boolean!'
             self.value = value
         else:
             self.value = bool(value)
@@ -206,9 +205,11 @@ def std_check(dataset, name):
 
     return False
 
+
 def xpath_check(tree, xpath):
     """Checks whether tree contains one or more elements matching xpath"""
     return len(xpath(tree)) > 0
+
 
 def attr_check(l, ds, priority, ret_val):
     """
@@ -314,9 +315,11 @@ def fix_return_value(v, method_name, method=None, checker=None):
 
     return v
 
+
 def ratable_result(value, name, msgs):
     """Returns a partial function with a Result that has not been weighted."""
     return lambda w: Result(w, value, name, msgs)
+
 
 def score_group(group_name=None):
     def _inner(func):

--- a/compliance_checker/cf/__init__.py
+++ b/compliance_checker/cf/__init__.py
@@ -1,2 +1,12 @@
-from compliance_checker.cf.cf import *
+from compliance_checker.cf.cf import (
+    CFBaseCheck,
+    util,
+)
+
 from compliance_checker.cf.appendix_d import dimless_vertical_coordinates
+
+__all__ = [
+    'CFBaseCheck',
+    'dimless_vertical_coordinates',
+    'util',
+]

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -33,6 +33,7 @@ def print_exceptions(f):
             print_exc()
     return wrapper
 
+
 __stdname_table__ = "v29"
 
 
@@ -972,8 +973,11 @@ class CFBaseCheck(BaseCheck):
                                                                standard_name)
 
         # If the variable is supposed to be unitless, it automatically passes
-        should_be_unitless = (variable.ndim == 0 or variable.dtype.char == 'S'
-                              or std_name_unitless)
+        should_be_unitless = (
+            variable.ndim == 0 or
+            variable.dtype.char == 'S' or
+            std_name_unitless
+        )
 
         valid_udunits = TestCtx(BaseCheck.LOW,
                                 "§3.1 Variable {}'s units are contained in UDUnits".format(variable_name))
@@ -1918,9 +1922,8 @@ class CFBaseCheck(BaseCheck):
 
         # if has a calendar, check that it is within the valid values
         # otherwise no calendar is valid
-        for time_var in \
-            ds.get_variables_by_attributes(calendar=lambda c: c is not None):
-            reasoning=None
+        for time_var in ds.get_variables_by_attributes(calendar=lambda c: c is not None):
+            reasoning = None
             valid_calendar = time_var.calendar in valid_calendars
 
             if not valid_calendar:
@@ -2513,7 +2516,7 @@ class CFBaseCheck(BaseCheck):
             if boundary_variable_name not in ds.variables:
                 valid = False
                 reasoning.append("Boundary variable {} referenced by {} not "
-                                 "found in dataset variables".format(boundary_variable.name,
+                                 "found in dataset variables".format(boundary_variable_name,
                                                                      variable.name))
             else:
                 boundary_variable = ds.variables[boundary_variable_name]
@@ -2532,20 +2535,22 @@ class CFBaseCheck(BaseCheck):
                                   boundary_variable.name,
                                   boundary_variable.ndim,
                                   variable.ndim + 1))
-            if (variable.dimensions[:] !=
-                  boundary_variable.dimensions[:variable.ndim]):
+            if (variable.dimensions[:] != boundary_variable.dimensions[:variable.ndim]):
                 valid = False
-                reasoning.append(u"Boundary variable coordinates are in improper order: {}. Bounds-specific dimensions should be last".format(
-                                boundary_variable.dimensions))
+                reasoning.append(
+                    u"Boundary variable coordinates are in improper order: {}. Bounds-specific dimensions should be last".format(
+                        boundary_variable.dimensions)
+                )
 
             # ensure p vertices form a valid simplex given previous a...n
             # previous auxiliary coordinates
-            if (ds.dimensions[boundary_variable.dimensions[-1]].size <
-                len(boundary_variable.dimensions[:-1]) + 1):
+            if (ds.dimensions[boundary_variable.dimensions[-1]].size < len(boundary_variable.dimensions[:-1]) + 1):
                 valid = False
-                reasoning.append("Boundary variable dimension {} must have at least {} elements to form a simplex/closed cell with previous dimensions {}.".format(boundary_variable.name,
-                                                                                                                                                          len(variable.dimensions) + 1,
-                                                                                                                                                          boundary_variable.dimensions[:-1]))
+                reasoning.append("Boundary variable dimension {} must have at least {} elements to form a simplex/closed cell with previous dimensions {}.".format(
+                    boundary_variable.name,
+                    len(variable.dimensions) + 1,
+                    boundary_variable.dimensions[:-1])
+                )
             result = Result(BaseCheck.MEDIUM, valid,
                             "§7.1 Cell boundaries are valid for variable {}".format(variable_name),
                             reasoning)
@@ -2589,25 +2594,30 @@ class CFBaseCheck(BaseCheck):
                 valid = True
                 cell_meas_var_name = search_res.groups[0]
                 # TODO: cache previous results
-                if not cell_meas_var_name in ds.variables:
+                if cell_meas_var_name not in ds.variables:
                     valid = False
-                    reasoning.append("Cell measure variable {} referred to by "
-                                     "{} is not present in dataset variables".format(
-                                                var_name, cell_meas_var_name))
+                    reasoning.append(
+                        "Cell measure variable {} referred to by "
+                        "{} is not present in dataset variables".format(
+                            var_name, cell_meas_var_name)
+                    )
                 else:
                     cell_meas_var = ds.variables[cell_meas_var_name]
                     if not hasattr(cell_meas_var, 'units'):
                         valid = False
-                        reasoning.append("Cell measure variable {} is required "
-                                         "to have units attribute defined.".format(
-                                                        cell_meas_var_name))
-                    if not set(cell_meas_var.dimensions).issubset(
-                                               var.dimensions):
+                        reasoning.append(
+                            "Cell measure variable {} is required "
+                            "to have units attribute defined.".format(
+                                cell_meas_var_name)
+                        )
+                    if not set(cell_meas_var.dimensions).issubset(var.dimensions):
                         valid = False
-                        reasoning.append("Cell measure variable {} must have "
-                                         "dimensions which are a subset of "
-                                         "those defined in variable {}.".format(
-                                                  cell_meas_var_name, var_name))
+                        reasoning.append(
+                            "Cell measure variable {} must have "
+                            "dimensions which are a subset of "
+                            "those defined in variable {}.".format(
+                                cell_meas_var_name, var_name)
+                        )
 
             result = Result(BaseCheck.MEDIUM,
                             valid,
@@ -2762,7 +2772,7 @@ class CFBaseCheck(BaseCheck):
         # but not the attribute "bounds"
         meth_regex = "(?:{})".format("|".join(methods))
         clim_containing_vars = ds.get_variables_by_attributes(
-                                        climatology=lambda s: s is not None)
+            climatology=lambda s: s is not None)
         clim_var = clim_containing_vars[0] if clim_containing_vars else None
         if clim_var:
             if hasattr(clim_var, 'bounds'):
@@ -2784,7 +2794,6 @@ class CFBaseCheck(BaseCheck):
                 return ret_val
             # handle 1-d and 2d coordinate bounds
             if (clim_var.ndim + 1 != ds.variables[clim_var.climatology].ndim):
-                valid = False
                 # Probably realistically need two dimensions in majority of
                 # practical cases.
                 reasoning.append('The number of dimensions of the climatology variable %s is %s, but the '
@@ -2800,17 +2809,18 @@ class CFBaseCheck(BaseCheck):
             # make sure last elements are boundary variable specific dimensions
             elif (clim_var.dimensions[:] !=
                   ds.variables[clim_var.climatology].dimensions[:clim_var.ndim]):
-                valid = False
-                reasoning.append(u"Climatology variable coordinates are in improper order: {}. Bounds-specific dimensions should be last".format(
-                                ds.variables[clim_var.climatology].dimensions))
+                reasoning.append(
+                    u"Climatology variable coordinates are in improper order: {}. Bounds-specific dimensions should be last".format(
+                        ds.variables[clim_var.climatology].dimensions)
+                )
                 return ret_val
             elif ds.dimensions[ds.variables[clim_var.climatology].dimensions[-1]].size != 2:
-                valid = False
-                reasoning.append(u"Climatology dimension {} should only contain two elements".format(
-                                boundary_variable.dimensions))
+                reasoning.append(
+                    u"Climatology dimension {} should only contain two elements".format(
+                        boundary_variable.dimensions)
+                )
         # catchall
         return ret_val
-
 
         # otherwise match the following values with for variable with
         # `cell_methods` attributes
@@ -2841,7 +2851,6 @@ class CFBaseCheck(BaseCheck):
             ret_val.append(result)
 
         return ret_val
-
 
     ###############################################################################
     #
@@ -2941,7 +2950,6 @@ class CFBaseCheck(BaseCheck):
             ret_val.append(result)
 
         return ret_val
-
 
     def check_compression_gathering(self, ds):
         """

--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -337,6 +337,7 @@ def download_cf_standard_name_table(version, location=None):
         r.raise_for_status()
     return
 
+
 def create_cached_data_dir():
     '''
     Returns the path to the data directory to download CF standard names.
@@ -349,6 +350,7 @@ def create_cached_data_dir():
         os.makedirs(data_directory)
 
     return data_directory
+
 
 def units_known(units):
     try:

--- a/compliance_checker/cfutil.py
+++ b/compliance_checker/cfutil.py
@@ -7,7 +7,6 @@ from cf_units import Unit
 from pkg_resources import resource_filename
 from collections import defaultdict
 import csv
-import json
 import re
 
 # For python2/python3 support

--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -12,7 +12,6 @@ class IOOSBaseCheck(BaseCheck):
     # requires login
     _cc_url = 'https://docs.google.com/spreadsheets/d/1huUFauh7rPj2oKfiRhLE1ZCsnes8SmAm6fKE95dsybE/'
 
-
     @classmethod
     def _has_attr(cls, ds, attr, concept_name, priority=BaseCheck.HIGH):
         """
@@ -198,7 +197,7 @@ class IOOSSOSGCCheck(BaseSOSGCCheck, IOOSBaseCheck):
             ('service_type_version', XPath("/sos:Capabilities/ows:ServiceIdentification/ows:ServiceTypeVersion", namespaces=self.ns)),
             # ds.identification[0].observed_properties has this as well, but
             # don't want to try to shoehorn a function here
-            #('variable_names', len(ds.identification[0].observed_properties) > 0)
+            # ('variable_names', len(ds.identification[0].observed_properties) > 0)
             ('variable_names', XPath("/sos:Capabilities/sos:Contents/sos:ObservationOfferingList/sos:ObservationOffering/sos:observedProperty",
              namespaces=self.ns)),
             ('data_format_template_version', XPath("/sos:Capabilities/ows:OperationsMetadata/ows:ExtendedCapabilities/gml:metaDataProperty[@xlink:title='ioosTemplateVersion']/gml:version",

--- a/compliance_checker/runner.py
+++ b/compliance_checker/runner.py
@@ -8,6 +8,7 @@ import json
 from contextlib import contextmanager
 from compliance_checker.suite import CheckSuite
 
+
 # Py 3.4+ has contextlib.redirect_stdout to redirect stdout to a different
 # stream, but use this decorated function in order to redirect output in
 # previous versions
@@ -19,6 +20,7 @@ def stdout_redirector(stream):
         yield
     finally:
         sys.stdout = old_stdout
+
 
 class ComplianceChecker(object):
     """

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -10,7 +10,6 @@ import subprocess
 import inspect
 import itertools
 from operator import itemgetter
-import json
 from netCDF4 import Dataset
 from lxml import etree as ET
 from compliance_checker.base import fix_return_value, Result
@@ -539,14 +538,14 @@ class CheckSuite(object):
                 # http://stackoverflow.com/a/7392391/84732
                 if sys.version_info >= (3, ):
                     join_str = ''
-                    textchars = join_str.join(map(chr, [7, 8, 9, 10, 12, 13, 27]
-                                                  + list(range(0x20, 0x100)))).encode()
+                    textchars = join_str.join(map(chr, [7, 8, 9, 10, 12, 13, 27] +
+                                                  list(range(0x20, 0x100)))).encode()
                 else:
                     # because of `unicode_literals` import, we need to convert
                     # to a Py2 string/bytes
                     join_str = str('')
-                    textchars = join_str.join(map(chr, [7, 8, 9, 10, 12, 13, 27]
-                                                  + list(range(0x20, 0x100))))
+                    textchars = join_str.join(map(chr, [7, 8, 9, 10, 12, 13, 27] +
+                                                  list(range(0x20, 0x100))))
                 return bool(bts.translate(None, textchars))
 
             def is_cdl_file(filename, data):

--- a/compliance_checker/tests/__init__.py
+++ b/compliance_checker/tests/__init__.py
@@ -38,4 +38,3 @@ class BaseTestCase(unittest.TestCase):
             assert result.value is False
         else:
             assert result.value[0] != result.value[1]
-

--- a/compliance_checker/tests/resources.py
+++ b/compliance_checker/tests/resources.py
@@ -17,6 +17,7 @@ def get_filename(path):
 def generate_dataset(cdl_path, nc_path):
     subprocess.call(['ncgen', '-o', nc_path, cdl_path])
 
+
 STATIC_FILES = {
     'rutgers'                              : get_filename('tests/data/ru07-20130824T170228_rt0.cdl'),
     'conv_multi'                           : get_filename('tests/data/conv_multi.cdl'),
@@ -84,7 +85,6 @@ STATIC_FILES = {
     'bounds_bad_order'                     : get_filename('tests/data/non-comp/bounds_bad_order.cdl'),
     'bounds_bad_num_coords'                : get_filename('tests/data/non-comp/bounds_bad_num_coords.cdl'),
     '1d_bound_bad'                         : get_filename('tests/data/non-comp/1d_bound_bad.cdl'),
-    'cf_example_cell_measures'             : get_filename('tests/data/cf_example_cell_measures.cdl'),
     'h_point'                              : get_filename('tests/data/appendix_h/point.cdl'),
     'h_timeseries-incomplete'              : get_filename('tests/data/appendix_h/timeseries-incomplete.cdl'),
     'h_timeseries-orthogonal'              : get_filename('tests/data/appendix_h/timeseries-orthogonal.cdl'),

--- a/compliance_checker/tests/test_base.py
+++ b/compliance_checker/tests/test_base.py
@@ -8,6 +8,7 @@ from netCDF4 import Dataset
 from compliance_checker import base
 import os
 
+
 class TestBase(TestCase):
     '''
     Tests functionality of the base compliance checker class
@@ -27,17 +28,17 @@ class TestBase(TestCase):
         attr = 'test'
         base.attr_check(attr, self.ds, priority, rv1)
         assert rv1[0] == base.Result(priority, False, 'test',
-                                  ['Attr test not present'])
+                                     ['Attr test not present'])
         # test with empty string
         self.ds.test = ''
         base.attr_check(attr, self.ds, priority, rv2)
         assert rv2[0] == base.Result(priority, False, 'test',
-                                ["Attr test is empty or completely whitespace"])
+                                     ["Attr test is empty or completely whitespace"])
         # test with whitespace in the form of a space and a tab
         self.ds.test = ' 	'
         base.attr_check(attr, self.ds, priority, rv3)
         assert rv3[0] == base.Result(priority, False, 'test',
-                                ["Attr test is empty or completely whitespace"])
+                                     ["Attr test is empty or completely whitespace"])
         # test with actual string contents
         self.ds.test = 'abc 123'
         base.attr_check(attr, self.ds, priority, rv4)
@@ -73,7 +74,7 @@ class TestBase(TestCase):
         attr = ('dummy', verify_dummy)
         base.attr_check(attr, self.ds, priority, rv1)
         assert rv1[0] == base.Result(priority, False, 'dummy',
-                                  ['Attr dummy not present'])
+                                     ['Attr dummy not present'])
         self.ds.dummy = 'doomy'
         base.attr_check(attr, self.ds, priority, rv2)
         assert rv2[0] == base.Result(priority, False, 'dummy', ['not "dummyy"'])

--- a/compliance_checker/tests/test_cf_integration.py
+++ b/compliance_checker/tests/test_cf_integration.py
@@ -9,7 +9,6 @@ from compliance_checker.tests import BaseTestCase
 
 import pytest
 import os
-import re
 
 
 class TestCFIntegration(BaseTestCase):

--- a/compliance_checker/tests/test_ioos.py
+++ b/compliance_checker/tests/test_ioos.py
@@ -4,7 +4,7 @@ from compliance_checker.runner import ComplianceChecker
 import os
 import sys
 
-if sys.version_info < (3,0):
+if sys.version_info < (3, 0):
     import httpretty
 else:
     httpretty = False
@@ -15,12 +15,11 @@ if httpretty:
 
         def setUp(self):
             with open(os.path.join(os.path.dirname(__file__),
-                        'data/http_mocks/ncsos_getcapabilities.xml')) as f:
+                                   'data/http_mocks/ncsos_getcapabilities.xml')) as f:
                 self.resp = f.read()
             # need to monkey patch checkers prior to running tests, or no checker
             # classes will show up
             CheckSuite().load_all_available_checkers()
-
 
         @httpretty.activate
         def test_retrieve_getcaps(self):
@@ -31,19 +30,18 @@ if httpretty:
             # recognizes this as some sort of XML doc instead of an OPeNDAP
             # source
             httpretty.register_uri(httpretty.HEAD, url, status=200,
-                                    content_type='text/xml')
+                                   content_type='text/xml')
             ComplianceChecker.run_checker(url, ['ioos'], 1, 'normal')
 
     class TestIOOSSOSDescribeSensor(unittest.TestCase):
 
         def setUp(self):
             with open(os.path.join(os.path.dirname(__file__),
-                        'data/http_mocks/ncsos_describesensor.xml')) as f:
+                                   'data/http_mocks/ncsos_describesensor.xml')) as f:
                 self.resp = f.read()
             # need to monkey patch checkers prior to running tests, or no checker
             # classes will show up
             CheckSuite().load_all_available_checkers()
-
 
         @httpretty.activate
         def test_retrieve_describesensor(self):
@@ -54,5 +52,5 @@ if httpretty:
             # recognizes this as some sort of XML doc instead of an OPeNDAP
             # source
             httpretty.register_uri(httpretty.HEAD, url, status=200,
-                                    content_type='text/xml')
+                                   content_type='text/xml')
             ComplianceChecker.run_checker(url, ['ioos'], 1, 'normal')

--- a/compliance_checker/tests/test_suite.py
+++ b/compliance_checker/tests/test_suite.py
@@ -1,4 +1,3 @@
-from compliance_checker import acdd
 from pkg_resources import resource_filename
 from compliance_checker.suite import CheckSuite
 from compliance_checker.base import Result, BaseCheck
@@ -39,10 +38,7 @@ class TestSuite(unittest.TestCase):
         cs = CheckSuite()
         cs.load_all_available_checkers()
         ds = cs.load_dataset(static_files['2dim'])
-        vals = cs.run(ds, 'acdd')
-
-        # run no longer returns the summed score, so this test.. just runs
-        # assert vals['acdd'][0] == (43.5, 78)
+        cs.run(ds, 'acdd')
 
     def test_unicode_formatting(self):
         cs = CheckSuite()
@@ -87,11 +83,12 @@ class TestSuite(unittest.TestCase):
         # if some assumptions are not met, e.g. if a Result object has
         # a value attribute of unexpected type
         cs = CheckSuite()
-        res = [Result(BaseCheck.MEDIUM, True, 'one'),
-               Result(BaseCheck.MEDIUM, (1, 3), 'one'),
-               Result(BaseCheck.MEDIUM, None, 'one'),
-               Result(BaseCheck.MEDIUM, True, 'two'),
-               Result(BaseCheck.MEDIUM, np.isnan(1), 'two')  # value is type numpy.bool_
+        res = [
+            Result(BaseCheck.MEDIUM, True, 'one'),
+            Result(BaseCheck.MEDIUM, (1, 3), 'one'),
+            Result(BaseCheck.MEDIUM, None, 'one'),
+            Result(BaseCheck.MEDIUM, True, 'two'),
+            Result(BaseCheck.MEDIUM, np.isnan(1), 'two')  # value is type numpy.bool_
         ]
         score = cs.scores(res)
         self.assertEqual(score[0].name, 'one')

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ def readme():
     with open('README.md') as f:
         return f.read()
 
+
 reqs = [line.strip() for line in open('requirements.txt')]
 
 setup(


### PR DESCRIPTION
This PR reduces the lints from:

```shell
1     E124 closing bracket does not match visual indentation
1     E125 continuation line with same indent as next logical line
9     E126 continuation line over-indented for hanging indent
3     E127 continuation line over-indented for visual indent
7     E128 continuation line under-indented for visual indent
1     E129 visually indented line with same indent as next logical line
2     E225 missing whitespace around operator
1     E231 missing whitespace after ','
1     E265 block comment should start with '# '
9     E302 expected 2 blank lines, found 1
6     E303 too many blank lines (2)
4     E305 expected 2 blank lines after class or function definition, found 1
1     E713 test for membership should be 'not in'
9     F401 'numpy.ma' imported but unused
1     F403 'from compliance_checker.cf.cf import *' used; unable to detect undefined names
2     F601 dictionary key 'cf_example_cell_measures' repeated with different values
2     F821 undefined name 'boundary_variable'
2     F841 local variable 'valid' is assigned to but never used
2     W391 blank line at end of file
3     W503 line break before binary operator
```

to

```shell
1     F821 undefined name 'boundary_variable'
```

Please merge with caution as some apperently unused variables and import were removed! I guess that `./compliance_checker/cf/cf.py` deserves most of the attention.