### PR TITLE
Add a test that should fail

### DIFF
--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -261,11 +261,8 @@ class StandardNameTable(object):
 
     def __init__(self, cached_location=None):
         if cached_location:
-            try:
-                with io.open(cached_location, 'r', encoding='utf-8') as fp:
-                    resource_text = fp.read()
-            except Exception:
-                resource_text = get_data("compliance_checker", "data/cf-standard-name-table.xml")
+            with io.open(cached_location, 'r', encoding='utf-8') as fp:
+                resource_text = fp.read()
         else:
             resource_text = get_data("compliance_checker", "data/cf-standard-name-table.xml")
 

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -12,6 +12,7 @@ from compliance_checker.tests import BaseTestCase
 import os
 import re
 import sys
+import pytest
 
 
 class MockVariable(object):
@@ -389,6 +390,13 @@ class TestCF(BaseTestCase):
         std_names = StandardNameTable(location)
         self.assertEqual(std_names._version, version)
         self.addCleanup(os.remove, location)
+
+    def test_bad_standard_name_table(self):
+        """
+        Test that failure in case a bad standard name table is passed.
+        """
+        with pytest.raises(IOError):
+            StandardNameTable('dummy_non_existent_file.ext')
 
     def test_check_flags(self):
         dataset = self.load_dataset(STATIC_FILES['rutgers'])


### PR DESCRIPTION
@lukecampbell I am putting https://github.com/ioos/compliance-checker/pull/482/commits/e38d3962571c3c9661309644d17d09a8c37171cb#r110988217 in from of a PR.

I added a test that passes a non-existent table file to `StandardNameTable`. That should fail b/c there is no such file but it does not raise the expected `IOError` and `compliance-checker`, silently, uses a default table instead. Users relying on that API may be getting the wrong table version without knowing. Because `StandardNameTable` is part of the public API I believe that we should change that behavior and fail gracefully. My next commit will change the code with that suggestion.