### PR TITLE
Adds better support for detecting dataset protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
   include:
   - python: 2.7
     env: TEST_TARGET=default
+  - python: 2.7
+    env: TEST_TARGET=integration
   - python: 3.4
     env: TEST_TARGET=default
   - python: 3.5
@@ -15,6 +17,8 @@ matrix:
     env: TEST_TARGET=default
   - python: 3.6
     env: TEST_TARGET=coding_standards
+  - python: 3.6
+    env: TEST_TARGET=integration
   allow_failures:
   - python: 3.6
     env: TEST_TARGET=coding_standards

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
   allow_failures:
   - python: 3.6
     env: TEST_TARGET=coding_standards
+  - python: 2.7
+    env: TEST_TARGET=integration
+  - python: 3.6
+    env: TEST_TARGET=integration
 
 before_install:
   - wget http://bit.ly/miniconda -O miniconda.sh
@@ -42,4 +46,8 @@ script:
 
   - if [[ $TEST_TARGET == "coding_standards" ]]; then
       flake8 --ignore=E501,E251,E221,E201,E202,E203 -qq --statistics . ;
+    fi
+
+  - if [[ $TEST_TARGET == "integration" ]]; then
+      py.test -m "integration" -s -rxs -v ;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
 
 script:
   - if [[ $TEST_TARGET == "default" ]]; then
-      py.test -s -rxs -v ;
+      py.test -k "not integration" -s -rxs -v ;
     fi
 
   - if [[ $TEST_TARGET == "coding_standards" ]]; then

--- a/compliance_checker/protocols/cdl.py
+++ b/compliance_checker/protocols/cdl.py
@@ -24,8 +24,9 @@ def is_cdl(filename):
     :param str filename: Absolute path of file to check
     :param str data: First chuck of data from file to check
     '''
-    if os.path.splitext(filename)[-1] == '.cdl':
-        return True
+    if os.path.splitext(filename)[-1] != '.cdl':
+        return False
+
     with open(filename, 'rb') as f:
         data = f.read(32)
     if data.startswith(b'netcdf') or b'dimensions' in data:

--- a/compliance_checker/protocols/cdl.py
+++ b/compliance_checker/protocols/cdl.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+'''
+compliance_checker/protocols/cdl.py
+'''
+import os
+
+
+def is_cdl(filename):
+    '''
+    Quick check for .cdl ascii file
+
+    Example:
+        netcdf sample_file {
+        dimensions:
+            name_strlen = 7 ;
+            time = 96 ;
+        variables:
+            float lat ;
+                lat:units = "degrees_north" ;
+                lat:standard_name = "latitude" ;
+                lat:long_name = "station latitude" ;
+        etc...
+
+    :param str filename: Absolute path of file to check
+    :param str data: First chuck of data from file to check
+    '''
+    if os.path.splitext(filename)[-1] == '.cdl':
+        return True
+    with open(filename, 'rb') as f:
+        data = f.read(32)
+    if data.startswith(b'netcdf') or b'dimensions' in data:
+        return True
+    return False

--- a/compliance_checker/protocols/netcdf.py
+++ b/compliance_checker/protocols/netcdf.py
@@ -8,7 +8,7 @@ Functions to assist in determining if the URL points to a netCDF file
 
 def is_netcdf(url):
     '''
-    Returns True if the URL is a valid OPeNDAP URL
+    Returns True if the URL points to a valid local netCDF file
 
     :param str url: Location of file on the file system
     '''

--- a/compliance_checker/protocols/netcdf.py
+++ b/compliance_checker/protocols/netcdf.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+'''
+compliance_checker/protocols/netcdf.py
+
+Functions to assist in determining if the URL points to a netCDF file
+'''
+
+
+def is_netcdf(url):
+    '''
+    Returns True if the URL is a valid OPeNDAP URL
+
+    :param str url: Location of file on the file system
+    '''
+    # Try an obvious exclusion of remote resources
+    if url.startswith('http'):
+        return False
+
+    # If it's a known extension, give it a shot
+    if url.endswith('nc'):
+        return True
+
+    # Brute force
+    with open(url, 'rb') as f:
+        magic_number = f.read(4)
+        if len(magic_number) < 4:
+            return False
+        if is_classic_netcdf(magic_number):
+            return True
+        elif is_hdf5(magic_number):
+            return True
+
+        return False
+
+
+def is_classic_netcdf(file_buffer):
+    '''
+    Returns True if the contents of the byte array matches the magic number in
+    netCDF files
+
+    :param str file_buffer: Byte-array of the first 4 bytes of a file
+    '''
+    # CDF.
+    if file_buffer == b'\x43\x44\x46\x01':
+        return True
+    return False
+
+
+def is_hdf5(file_buffer):
+    '''
+    Returns True if the contents of the byte array matches the magic number in
+    HDF5 files
+
+    :param str file_buffer: Byte-array of the first 4 bytes of a file
+    '''
+    # .HDF
+    if file_buffer == b'\x89\x48\x44\x46':
+        return True
+    return False

--- a/compliance_checker/protocols/opendap.py
+++ b/compliance_checker/protocols/opendap.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+'''
+compliance_checker/protocols/opendap.py
+
+Functions to assist in determining if the URL is an OPeNDAP endpoint
+'''
+import requests
+
+
+def is_opendap(url):
+    '''
+    Returns True if the URL is a valid OPeNDAP URL
+
+    :param str url: URL for a remote OPeNDAP endpoint
+    '''
+    # If the server replies to a Data Attribute Structure request
+    das_url = url + '.das'
+    response = requests.get(das_url, allow_redirects=True)
+    if 'xdods-server' in response.headers:
+        return True
+    return False
+
+

--- a/compliance_checker/protocols/opendap.py
+++ b/compliance_checker/protocols/opendap.py
@@ -19,5 +19,3 @@ def is_opendap(url):
     if 'xdods-server' in response.headers:
         return True
     return False
-
-

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -533,6 +533,8 @@ class CheckSuite(object):
         if opendap.is_opendap(ds_str):
             return Dataset(ds_str)
         else:
+            # Check if the HTTP response is XML, if it is, it's likely SOS so
+            # we'll attempt to parse the response as SOS
             response = requests.get(ds_str, allow_redirects=True)
             if 'text/xml' in response.headers['content-type']:
                 return self.process_doc(response.content)

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -16,6 +16,7 @@ from lxml import etree as ET
 from compliance_checker.base import fix_return_value, Result
 from owslib.sos import SensorObservationService
 from owslib.swe.sensor.sml import SensorML
+from compliance_checker.protocols import opendap, netcdf, cdl
 try:
     from urlparse import urlparse
 except ImportError:
@@ -511,87 +512,46 @@ class CheckSuite(object):
 
     def load_dataset(self, ds_str):
         """
-        Helper method to load a dataset or SOS GC/DS url.
+        Returns an instantiated instance of either a netCDF file or an SOS
+        mapped DS object.
+
+        :param str ds_str: URL of the resource to load
         """
-        ds = None
-        # try to figure out if this is a local NetCDF Dataset, a remote one, or an SOS GC/DS url
-        doc = None
+        # If it's a remote URL load it as a remote resource, otherwise treat it
+        # as a local resource.
         pr = urlparse(ds_str)
-        if pr.netloc:       # looks like a remote url
-            rhead = requests.head(ds_str, allow_redirects=True)
-            # if we get a 400 here, it's likely a Dataset openable OpenDAP url
-            if rhead.status_code == 400 or rhead.status_code == 401:
-                pass
-            elif rhead.status_code == 200 and rhead.headers['content-type'] == 'text/xml':
-                # probably interesting, grab it
-                r = requests.get(ds_str)
-                r.raise_for_status()
+        if pr.netloc:
+            return self.load_remote_dataset(ds_str)
+        return self.load_local_dataset(ds_str)
 
-                # need to use content to get bytes, as text will return unicode
-                # in Python3, which will break etree.fromstring if encoding
-                # is also declared in the XML doc
-                doc = r.content
-            else:
-                raise Exception("Could not understand response code %s and content-type %s" % (rhead.status_code, rhead.headers.get('content-type', 'none')))
+    def load_remote_dataset(self, ds_str):
+        '''
+        Returns a dataset instance for the remote resource, either OPeNDAP or SOS
+
+        :param str ds_str: URL to the remote resource
+        '''
+        if opendap.is_opendap(ds_str):
+            return Dataset(ds_str)
         else:
-            def is_binary_string(bts):
-                # do a cheap imitation of libmagic
-                # http://stackoverflow.com/a/7392391/84732
-                if sys.version_info >= (3, ):
-                    join_str = ''
-                    textchars = join_str.join(map(chr, [7, 8, 9, 10, 12, 13, 27]
-                                                  + list(range(0x20, 0x100)))).encode()
-                else:
-                    # because of `unicode_literals` import, we need to convert
-                    # to a Py2 string/bytes
-                    join_str = str('')
-                    textchars = join_str.join(map(chr, [7, 8, 9, 10, 12, 13, 27]
-                                                  + list(range(0x20, 0x100))))
-                return bool(bts.translate(None, textchars))
+            response = requests.get(ds_str, allow_redirects=True)
+            if 'text/xml' in response.headers['content-type']:
+                return self.process_doc(response.content)
 
-            def is_cdl_file(filename, data):
-                '''
-                Quick check for .cdl ascii file
+            raise ValueError("Unknown service with content-type: {}".format(response.headers['content-type']))
 
-                Example:
-                    netcdf sample_file {
-                    dimensions:
-                        name_strlen = 7 ;
-                        time = 96 ;
-                    variables:
-                        float lat ;
-                            lat:units = "degrees_north" ;
-                            lat:standard_name = "latitude" ;
-                            lat:long_name = "station latitude" ;
-                    etc...
+    def load_local_dataset(self, ds_str):
+        '''
+        Returns a dataset instance for the local resource
 
-                :param str filename: Absolute path of file to check
-                :param str data: First chuck of data from file to check
-                '''
-                if os.path.splitext(filename)[-1] == '.cdl':
-                    return True
-                if data.startswith(b'netcdf') or b'dimensions' in data:
-                    return True
-                return False
+        :param ds_str: Path to the resource
+        '''
+        if cdl.is_cdl(ds_str):
+            ds_str = self.generate_dataset(ds_str)
 
-            with open(ds_str, 'rb') as f:
-                first_chunk = f.read(1024)
-                if is_binary_string(first_chunk):
-                    # likely netcdf file
-                    pass
-                elif is_cdl_file(ds_str, first_chunk):
-                    ds_str = self.generate_dataset(ds_str)
-                else:
-                    f.seek(0)
-                    doc = f.read()
+        if netcdf.is_netcdf(ds_str):
+            return Dataset(ds_str)
 
-        if doc is not None:
-            ds = self.process_doc(doc)
-        else:
-            # no doc? try the dataset constructor
-            ds = Dataset(ds_str)
-
-        return ds
+        raise ValueError("File is an unknown format")
 
     def scores(self, raw_scores):
         """

--- a/compliance_checker/tests/test_ioos.py
+++ b/compliance_checker/tests/test_ioos.py
@@ -26,12 +26,10 @@ if httpretty:
         def test_retrieve_getcaps(self):
             """Method that simulates retrieving SOS GetCapabilities"""
             url = "http://data.oceansmap.com/thredds/sos/caricoos_ag/VIA/VIA.ncml"
-            httpretty.register_uri(httpretty.GET, url, body=self.resp)
+            httpretty.register_uri(httpretty.GET, url, content_type="text/xml", body=self.resp)
             # need to mock out the HEAD response so that compliance checker
             # recognizes this as some sort of XML doc instead of an OPeNDAP
             # source
-            httpretty.register_uri(httpretty.HEAD, url, status=200,
-                                    content_type='text/xml')
             ComplianceChecker.run_checker(url, ['ioos'], 1, 'normal')
 
     class TestIOOSSOSDescribeSensor(unittest.TestCase):
@@ -49,10 +47,8 @@ if httpretty:
         def test_retrieve_describesensor(self):
             """Method that simulates retrieving SOS DescribeSensor"""
             url = "http://data.oceansmap.com/thredds/sos/caricoos_ag/VIA/VIA.ncml?request=describesensor&service=sos&procedure=urn:ioos:station:ncsos:VIA&outputFormat=text/xml%3Bsubtype%3D%22sensorML/1.0.1/profiles/ioos_sos/1.0%22&version=1.0.0"
-            httpretty.register_uri(httpretty.GET, url, body=self.resp)
+            httpretty.register_uri(httpretty.GET, url, content_type="text/xml", body=self.resp)
             # need to mock out the HEAD response so that compliance checker
             # recognizes this as some sort of XML doc instead of an OPeNDAP
             # source
-            httpretty.register_uri(httpretty.HEAD, url, status=200,
-                                    content_type='text/xml')
             ComplianceChecker.run_checker(url, ['ioos'], 1, 'normal')

--- a/compliance_checker/tests/test_protocols.py
+++ b/compliance_checker/tests/test_protocols.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+'''
+compliance_checker/tests/test_protocols.py
+
+Unit tests that ensure the compliance checker can successfully identify protocol endpoints
+'''
+from unittest import TestCase
+from compliance_checker.suite import CheckSuite
+
+import pytest
+
+
+@pytest.mark.integration
+class TestProtocols(TestCase):
+
+    def test_erddap(self):
+        '''
+        Tests that a connection can be made to ERDDAP's GridDAP
+        '''
+        url = 'http://coastwatch.pfeg.noaa.gov/erddap/griddap/osuChlaAnom'
+        cs = CheckSuite()
+        ds = cs.load_dataset(url)
+        assert ds is not None
+
+    def test_hyrax(self):
+        '''
+        Tests that a connection can be made to Hyrax
+        '''
+        url = 'http://ingria.coas.oregonstate.edu/opendap/hyrax/aggregated/ocean_time_aggregation.ncml'
+        cs = CheckSuite()
+        ds = cs.load_dataset(url)
+        assert ds is not None
+
+    def test_thredds(self):
+        '''
+        Tests that a connection can be made to a remote THREDDS endpoint
+        '''
+        url = 'http://data.ioos.us/thredds/dodsC/deployments/rutgers/ru24-20150105T1441/ru24-20150105T1441.nc3.nc'
+        cs = CheckSuite()
+        ds = cs.load_dataset(url)
+        assert ds is not None
+
+    def test_sos(self):
+        '''
+        Tests that a connection can be made to an SOS endpoint
+        '''
+        url = 'http://data.oceansmap.com/thredds/sos/caricoos_ag/VIA/VIA.ncml'
+        cs = CheckSuite()
+        ds = cs.load_dataset(url)
+        assert ds is not None

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -37,5 +37,5 @@ test:
     - compliance_checker.cf
     - compliance_checker.tests
   commands:
-    - py.test -s -rxs -v compliance_checker
+    - py.test -s -rxs -v -k "not integration" compliance_checker
     - compliance-checker --help


### PR DESCRIPTION
We recently found out that Hyrax and ERDDAP did not work because the
server intitally returns a HTTP 200/Content-type: text/html when an HTTP
request is made to a DODS endpoint. This is so user's don't see the
error page that THREDDS shows when a user visits a pure DODS endpoint.

We relied on this behavior of THREDDS and the too literal interpretation
of DAPv2's specification to identify services implementing OPeNDAP.

This patch includes better identification of services implementing
OPeNDAP, and SOS. As well as a faster check for binary datasets like
netCDF.

Identification now works by checking if 'xdods-server' exists in the
response headers. In the case for SOS, if the response headers has
'text/xml' in the content-type header, then it is treated as an SOS
response.

Binary netCDF files are checked by the filename suffix or the magic
number (first four bytes of a file).