### PR TITLE
Adds better reasoning statement for Conventions check

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -738,15 +738,18 @@ class CFBaseCheck(BaseCheck):
         :rtype: compliance_checker.base.Result
         '''
 
-        valid_conventions = ['CF-1.6']
+        valid = False
+        reasoning = []
         if hasattr(ds, 'Conventions'):
             conventions = re.split(',|\s+', getattr(ds, 'Conventions', ''))
-            if any((c.strip() in valid_conventions for c in conventions)):
-                valid = True
-                reasoning = []
+            for convention in conventions:
+                if convention == 'CF-1.6':
+                    valid = True
+                    break
             else:
-                valid = False
-                reasoning = ['Conventions global attribute does not contain "CF-1.6"']
+                reasoning = ['Conventions global attribute does not contain '
+                             '"CF-1.6". The CF Checker only supports CF-1.6 '
+                             'at this time.']
         else:
             valid = False
             reasoning = ['Conventions field is not present']

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -200,7 +200,8 @@ class TestCF(BaseTestCase):
 
     def test_check_conventions_are_cf_16(self):
         """
-        2.6.1 the NUG defined global attribute Conventions to the string value "CF-1.6"
+        2.6.1 the NUG defined global attribute Conventions to the string value
+        "CF-1.6"
         """
         # :Conventions = "CF-1.6"
         dataset = self.load_dataset(STATIC_FILES['rutgers'])
@@ -216,7 +217,9 @@ class TestCF(BaseTestCase):
         dataset = self.load_dataset(STATIC_FILES['conv_bad'])
         result = self.cf.check_conventions_are_cf_16(dataset)
         self.assertFalse(result.value)
-        assert result.msgs[0] == 'Conventions global attribute does not contain "CF-1.6"'
+        assert result.msgs[0] == ('Conventions global attribute does not contain '
+                                  '"CF-1.6". The CF Checker only supports CF-1.6 '
+                                  'at this time.')
 
     def test_check_convention_globals(self):
         """

--- a/compliance_checker/tests/test_cf_integration.py
+++ b/compliance_checker/tests/test_cf_integration.py
@@ -94,7 +94,9 @@ class TestCFIntegration(BaseTestCase):
         assert (scored, out_of) == (1840, 1841)
         assert len(messages) == 41
         assert (u'Unidentifiable feature for variable Akt_bak') in messages
-        assert (u'Conventions global attribute does not contain "CF-1.6"') in messages
+        assert (u'Conventions global attribute does not contain '
+                 '"CF-1.6". The CF Checker only supports CF-1.6 '
+                 'at this time.') in messages
         assert (u"CF recommends latitude variable 'lat_psi' to use units degrees_north") in messages
 
     def test_l01_met(self):
@@ -117,7 +119,9 @@ class TestCFIntegration(BaseTestCase):
         scored, out_of, messages = self.get_results(check_results)
         assert (scored, out_of) == (109, 110)
         assert len(messages) == 1
-        assert (u'Conventions global attribute does not contain "CF-1.6"') == messages[0]
+        assert (u'Conventions global attribute does not contain '
+                 '"CF-1.6". The CF Checker only supports CF-1.6 '
+                 'at this time.') in messages
 
     def test_sp041(self):
         dataset = self.load_dataset(STATIC_FILES['sp041'])
@@ -176,7 +180,9 @@ class TestCFIntegration(BaseTestCase):
                 "is either 'up' or 'down'") in messages
         assert (u"GRID is not a valid CF featureType. It must be one of point, timeSeries, "
                 "trajectory, profile, timeSeriesProfile, trajectoryProfile") in messages
-        assert (u'Conventions global attribute does not contain "CF-1.6"') in messages
+        assert (u'Conventions global attribute does not contain '
+                 '"CF-1.6". The CF Checker only supports CF-1.6 '
+                 'at this time.') in messages
 
     def test_kibesillah(self):
         dataset = self.load_dataset(STATIC_FILES['kibesillah'])
@@ -221,7 +227,9 @@ class TestCFIntegration(BaseTestCase):
                                  "are not a subset of dimensions for variable u (siglay, nele, time)\""
                                  " not in messages")
         assert (u"Unidentifiable feature for variable x") in messages
-        assert (u'Conventions global attribute does not contain "CF-1.6"') in messages
+        assert (u'Conventions global attribute does not contain '
+                 '"CF-1.6". The CF Checker only supports CF-1.6 '
+                 'at this time.') in messages
         assert (u"siglay shares the same name as one of its dimensions") in messages
 
     def test_ww3(self):


### PR DESCRIPTION
The checker checks the Conventions global attribute but only allows
'CF-1.6' currently. This patch improves the reasoning message indicating
that the checker can only check CF-1.6 at the moment.

https://github.com/ioos/compliance-checker/issues/501