### PR TITLE
Use proper variable name for ancillary var check

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -1178,7 +1178,7 @@ class CFBaseCheck(BaseCheck):
                 continue
 
             for ancillary_variable in ancillary_variables.split():
-                valid_ancillary.assert_true(ancillary_variables in ds.variables,
+                valid_ancillary.assert_true(ancillary_variable in ds.variables,
                                             "{} is not a variable in this dataset".format(ancillary_variable))
 
             ret_val.append(valid_ancillary.to_result())


### PR DESCRIPTION
Uses `ancillary_variable in ds.variables` instead of
`ancillary_variables in ds.variables`.  Fixes #464.