### PR TITLE
Drop Python 3.4 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
     env: TEST_TARGET=default
   - python: 2.7
     env: TEST_TARGET=integration
-  - python: 3.4
-    env: TEST_TARGET=default
   - python: 3.5
     env: TEST_TARGET=default
   - python: 3.6


### PR DESCRIPTION
conda-forge dropped support for `Python 3.4` and we are testing against `Python 3.5` and `3.6`, so it is safe to drop it from here too.