### PR TITLE
Fix bug in check_cf_role

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -3199,11 +3199,12 @@ class CFBaseCheck(BaseCheck):
             valid_cf_role.assert_true(cf_role in valid_roles,
                                       "{} is not a valid cf_role value. It must be one of {}"
                                       "".format(name, ', '.join(valid_roles)))
-        valid_cf_role.assert_true(variable_count < 3,
-                                  ('§9.5 states that datasets should not '
-                                   'contain more than two variables defining a '
-                                   'cf_role attribute.'))
-        return valid_cf_role.to_result()
+        if variable_count > 0:
+            valid_cf_role.assert_true(variable_count < 3,
+                                      ('§9.5 states that datasets should not '
+                                       'contain more than two variables defining a '
+                                       'cf_role attribute.'))
+            return valid_cf_role.to_result()
 
     def check_variable_features(self, ds):
         '''


### PR DESCRIPTION
The way it was written, I was getting the following when running the tests.

```
compliance_checker/tests/test_cli.py::TestCLI::test_text_output WARNING: The following exceptions occured during the cf checker (possibly indicate compliance checker issues):
cf.check_cf_role: local variable 'valid_cf_role' referenced before assignment
```