### PR TITLE
Support showing output from multiple tests in HTML output

### DIFF
--- a/compliance_checker/data/templates/ccheck.html.j2
+++ b/compliance_checker/data/templates/ccheck.html.j2
@@ -1,351 +1,137 @@
-<!doctype html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <meta name="description" content="IOOS Compliance Checker Results">
-    <title>Compliance Checker</title>
-    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-    <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-    <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
-    <script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-    <style>
-.navbar-custom {
-  background-color: #c6d4e1;
-  border-size: 0px;
-  margin-bottom: 0px;
-  border-radius: 0px;
-}
-
-.navbar-custom .navbar-img-brand {
-  float: left;
-}
-
-.navbar-custom .navbar-img-brand img {
-  height: 47px;
-}
-
-.navbar-custom .navbar-brand {
-  color: #565c61;
-}
-.navbar-custom .navbar-brand:hover,
-.navbar-custom .navbar-brand:focus {
-  color: #3e4246;
-  background-color: transparent;
-}
-.navbar-custom .navbar-text {
-  color: #565c61;
-}
-.navbar-custom .navbar-nav > li > a {
-  color: #565c61;
-}
-.navbar-custom .navbar-nav > li > a:hover,
-.navbar-custom .navbar-nav > li > a:focus {
-  color: #333333;
-  background-color: transparent;
-}
-.navbar-custom .navbar-nav > .active > a,
-.navbar-custom .navbar-nav > .active > a:hover,
-.navbar-custom .navbar-nav > .active > a:focus {
-  color: #333333;
-  background-color: #b0c4d6;
-}
-.navbar-custom .navbar-nav > .disabled > a,
-.navbar-custom .navbar-nav > .disabled > a:hover,
-.navbar-custom .navbar-nav > .disabled > a:focus {
-  color: #cccccc;
-  background-color: transparent;
-}
-.navbar-custom .navbar-toggle {
-  border-color: #dddddd;
-}
-.navbar-custom .navbar-toggle:hover,
-.navbar-custom .navbar-toggle:focus {
-  background-color: #dddddd;
-}
-.navbar-custom .navbar-toggle .icon-bar {
-  background-color: #cccccc;
-}
-.navbar-custom .navbar-collapse,
-.navbar-custom .navbar-form {
-  border-color: #afc2d5;
-}
-.navbar-custom .navbar-nav > .dropdown > a:hover .caret,
-.navbar-custom .navbar-nav > .dropdown > a:focus .caret {
-  border-top-color: #333333;
-  border-bottom-color: #333333;
-}
-.navbar-custom .navbar-nav > .open > a,
-.navbar-custom .navbar-nav > .open > a:hover,
-.navbar-custom .navbar-nav > .open > a:focus {
-  background-color: #b0c4d6;
-  color: #333333;
-}
-.navbar-custom .navbar-nav > .open > a .caret,
-.navbar-custom .navbar-nav > .open > a:hover .caret,
-.navbar-custom .navbar-nav > .open > a:focus .caret {
-  border-top-color: #333333;
-  border-bottom-color: #333333;
-}
-.navbar-custom .navbar-nav > .dropdown > a .caret {
-  border-top-color: #565c61;
-  border-bottom-color: #565c61;
-}
-@media (max-width: 767) {
-  .navbar-custom .navbar-nav .open .dropdown-menu > li > a {
-    color: #565c61;
-  }
-  .navbar-custom .navbar-nav .open .dropdown-menu > li > a:hover,
-  .navbar-custom .navbar-nav .open .dropdown-menu > li > a:focus {
-    color: #333333;
-    background-color: transparent;
-  }
-  .navbar-custom .navbar-nav .open .dropdown-menu > .active > a,
-  .navbar-custom .navbar-nav .open .dropdown-menu > .active > a:hover,
-  .navbar-custom .navbar-nav .open .dropdown-menu > .active > a:focus {
-    color: #333333;
-    background-color: #b0c4d6;
-  }
-  .navbar-custom .navbar-nav .open .dropdown-menu > .disabled > a,
-  .navbar-custom .navbar-nav .open .dropdown-menu > .disabled > a:hover,
-  .navbar-custom .navbar-nav .open .dropdown-menu > .disabled > a:focus {
-    color: #cccccc;
-    background-color: transparent;
-  }
-}
-.navbar-custom .navbar-link {
-  color: #565c61;
-}
-.navbar-custom .navbar-link:hover {
-  color: #333333;
-}
-
-.bad-score {
-  color: #D70834;
-}
-
-thead .tname {
-  width: 60%;
-}
-thead .tpriority {
-  width: 20%;
-}
-
-thead .tscore {
-  width: 20%;
-}
-
-thead .cname {
-  width: 25%;
-}
-
-thead .cpriority {
-  width: 5%;
-}
-
-thead .ccorrection {
-  width: 70%;
-}
-
-.table-collapse {
-  display: inline;
-  font-size: 18px;
-  font-weight: bold;
-}
-
-.table-collapse a{
-  color: #333;
-}
-
-.table-collapse a:hover {
-  color: #777;
-  text-decoration: none;
-}
-
-.failures {
-  display: inline;
-}
-
-.label-as-badge {
-  border-radius: 1em;
-}
-    </style>
-
-  </head>
-  <body>
-  <header>
-      <nav class="navbar navbar-custom">
-        <div class="container">
-          <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#nb-collapse">
-              <span class="icon-bar"></span>
-              <span class="icon-bar"></span>
-              <span class="icon-bar"></span>
-            </button>
-            <a class="navbar-img-brand" href="http://ioos.noaa.gov/">
-              <img src="http://catalog.ioos.us/static/img/ioos.png" alt="IOOS Catalog" />
-            </a>
-            <div class="navbar-brand">
-              Compliance Checker
-            </div>
-          </div>
-      </nav>
-    </header>
-
-    <div class="container">
-      <div class="row">
-        <div class="col-md-12">
-          <div class="page-header">
-            <h3>Your dataset scored {{scored_points}} out of {{possible_points}} points</h3>
-            <p>During the {{testname}} check</p>
-            <p>For dataset {{source_name}}</p>
-          </div>
-        </div>
-        <div class="col-md-12">
-          <h4>
-            Scoring Breakdown:
-          </h4>
-        </div>
-        <div class="col-md-12">
-          <div class="table-collapse">
-            <a data-target="high-priority-table" href="#">High Priority <i class="glyphicon glyphicon-collapse-up"></i></a>
-          </div>
-          {% if high_count -%}
-          <div class="failures">
-            | <span class="label label-danger label-as-badge">{{ high_count }}</span>
-          </div>
+<!-- Template for the HTML markup for the results of a single test -->
+<div class="row">
+  <div class="col-md-12">
+    <div class="page-header">
+      <h3>Your dataset scored {{scored_points}} out of {{possible_points}} points</h3>
+      <p>During the {{testname}} check</p>
+      <p>For dataset {{source_name}}</p>
+    </div>
+  </div>
+  <div class="col-md-12">
+    <h4>
+      Scoring Breakdown:
+    </h4>
+  </div>
+  <div class="col-md-12">
+    <div class="table-collapse">
+      <a data-target="high-priority-table" href="#">High Priority <i class="glyphicon glyphicon-collapse-up"></i></a>
+    </div>
+    {% if high_count -%}
+    <div class="failures">
+      | <span class="label label-danger label-as-badge">{{ high_count }}</span>
+    </div>
+    {% endif -%}
+    <div class="high-priority-table collapse in">
+      <table class="table">
+        <thead>
+          <tr>
+            <th class="tname">Name</th>
+            <th class="tscore">Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for score in high_priorities -%}
+          {% if score['value'][0] < score['value'][1] -%}
+          <tr class="bad-score">
+          {% else -%}
+          <tr>
           {% endif -%}
-          <div class="high-priority-table collapse in">
-            <table class="table">
-              <thead>
-                <tr>
-                  <th class="tname">Name</th>
-                  <th class="tscore">Score</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for score in high_priorities -%}
-                {% if score['value'][0] < score['value'][1] -%}
-                <tr class="bad-score">
-                {% else -%}
-                <tr>
-                {% endif -%}
 
-                  <td>{{score['name']}}</td>
-                  <td>{{score['value'][0]}}/{{score['value'][1]}}</td>
-                </tr>
-                {% endfor -%}
-              </tbody>
-            </table>
-          </div> <!-- .high-priority-table -->
-        </div> <!-- .col-md-12 -->
-        <div class="col-md-12">
-          <div class="table-collapse">
-            <a data-target="medium-priority-table" href="#">Medium Priority <i class="glyphicon glyphicon-collapse-up"></i></a>
-          </div>
-          {% if medium_count -%}
-          <div class="failures">
-            | <span class="label label-danger label-as-badge">{{ medium_count }}</span>
-          </div>
+            <td>{{score['name']}}</td>
+            <td>{{score['value'][0]}}/{{score['value'][1]}}</td>
+          </tr>
+          {% endfor -%}
+        </tbody>
+      </table>
+    </div> <!-- .high-priority-table -->
+  </div> <!-- .col-md-12 -->
+  <div class="col-md-12">
+    <div class="table-collapse">
+      <a data-target="medium-priority-table" href="#">Medium Priority <i class="glyphicon glyphicon-collapse-up"></i></a>
+    </div>
+    {% if medium_count -%}
+    <div class="failures">
+      | <span class="label label-danger label-as-badge">{{ medium_count }}</span>
+    </div>
+    {% endif -%}
+    <div class="medium-priority-table collapse in">
+      <table class="table">
+        <thead>
+          <tr>
+            <th class="tname">Name</th>
+            <th class="tscore">Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for score in medium_priorities -%}
+          {% if score['value'][0] < score['value'][1] -%}
+          <tr class="bad-score">
+          {% else -%}
+          <tr>
           {% endif -%}
-          <div class="medium-priority-table collapse in">
-            <table class="table">
-              <thead>
-                <tr>
-                  <th class="tname">Name</th>
-                  <th class="tscore">Score</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for score in medium_priorities -%}
-                {% if score['value'][0] < score['value'][1] -%}
-                <tr class="bad-score">
-                {% else -%}
-                <tr>
-                {% endif -%}
 
-                  <td>{{score['name']}}</td>
-                  <td>{{score['value'][0]}}/{{score['value'][1]}}</td>
-                </tr>
-                {% endfor -%}
-              </tbody>
-            </table>
-          </div> <!-- .medium-priority-table -->
-        </div> <!-- .col-md-12 -->
-        <div class="col-md-12">
-          <div class="table-collapse">
-            <a data-target="low-priority-table" href="#">Low Priority <i class="glyphicon glyphicon-collapse-up"></i></a>
-          </div>
-          {% if low_count -%}
-          <div class="failures">
-            | <span class="label label-danger label-as-badge">{{ low_count }}</span>
-          </div>
+            <td>{{score['name']}}</td>
+            <td>{{score['value'][0]}}/{{score['value'][1]}}</td>
+          </tr>
+          {% endfor -%}
+        </tbody>
+      </table>
+    </div> <!-- .medium-priority-table -->
+  </div> <!-- .col-md-12 -->
+  <div class="col-md-12">
+    <div class="table-collapse">
+      <a data-target="low-priority-table" href="#">Low Priority <i class="glyphicon glyphicon-collapse-up"></i></a>
+    </div>
+    {% if low_count -%}
+    <div class="failures">
+      | <span class="label label-danger label-as-badge">{{ low_count }}</span>
+    </div>
+    {% endif -%}
+    <div class="low-priority-table collapse in">
+      <table class="table">
+        <thead>
+          <tr>
+            <th class="tname">Name</th>
+            <th class="tscore">Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for score in low_priorities -%}
+          {% if score['value'][0] < score['value'][1] -%}
+          <tr class="bad-score">
+          {% else -%}
+          <tr>
           {% endif -%}
-          <div class="low-priority-table collapse in">
-            <table class="table">
-              <thead>
-                <tr>
-                  <th class="tname">Name</th>
-                  <th class="tscore">Score</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for score in low_priorities -%}
-                {% if score['value'][0] < score['value'][1] -%}
-                <tr class="bad-score">
-                {% else -%}
-                <tr>
-                {% endif -%}
 
-                  <td>{{score['name']}}</td>
-                  <td>{{score['value'][0]}}/{{score['value'][1]}}</td>
-                </tr>
-                {% endfor -%}
-              </tbody>
-            </table>
-          </div>
-        </div> <!-- .col-md-12 -->
-        <div class="col-md-12">
-          <h4>Corrective Actions</h4>
-          <table class="table">
-            <thead>
-              <tr>
-                <th class="cname">Name</td>
-                <th class="cpriority">Priority</td>
-                <th class="ccorrection">Corrective action</td>
-              </tr>
-            </thead>
-            <tbody>
-            {% for result in all_priorities -%}
-              {% for msg in result['msgs']-%}
-                <tr>
-                  <td>{{result['name']}}</td>
-                  <td>{{result['weight']}}</td>
-                  <td>{{msg}}</td>
-                </tr>
-              {% endfor -%}
-            {% endfor -%}
-            </tbody>
-          </table>
-        </div> <!-- .col-md-12 -->
-      </div> <!-- .row -->
-    </div> <!-- .container -->
-    <script type="text/javascript">
-$(document).ready(function() {
-    $('.high-priority-table').collapse({toggle: false});
-    $('.table-collapse').click(function(e) {
-      e.preventDefault();
-      console.log("Collapse this table");
-      $('.' + $(e.target).data('target')).collapse('toggle');
-      var glyph = $(e.target).find('.glyphicon');
-      if(glyph.hasClass('glyphicon-collapse-up')) {
-        glyph.removeClass('glyphicon-collapse-up');
-        glyph.addClass('glyphicon-collapse-down');
-      } else {
-        glyph.removeClass('glyphicon-collapse-down');
-        glyph.addClass('glyphicon-collapse-up');
-      }
-    });
-});
-    </script>
-  </body>
-</html>
+            <td>{{score['name']}}</td>
+            <td>{{score['value'][0]}}/{{score['value'][1]}}</td>
+          </tr>
+          {% endfor -%}
+        </tbody>
+      </table>
+    </div>
+  </div> <!-- .col-md-12 -->
+  <div class="col-md-12">
+    <h4>Corrective Actions</h4>
+    <table class="table">
+      <thead>
+        <tr>
+          <th class="cname">Name</td>
+          <th class="cpriority">Priority</td>
+          <th class="ccorrection">Corrective action</td>
+        </tr>
+      </thead>
+      <tbody>
+      {% for result in all_priorities -%}
+        {% for msg in result['msgs']-%}
+          <tr>
+            <td>{{result['name']}}</td>
+            <td>{{result['weight']}}</td>
+            <td>{{msg}}</td>
+          </tr>
+        {% endfor -%}
+      {% endfor -%}
+      </tbody>
+    </table>
+  </div> <!-- .col-md-12 -->
+</div> <!-- .row -->

--- a/compliance_checker/data/templates/ccheck_wrapper.html.j2
+++ b/compliance_checker/data/templates/ccheck_wrapper.html.j2
@@ -1,0 +1,220 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="description" content="IOOS Compliance Checker Results">
+    <title>Compliance Checker</title>
+    <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+    <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+    <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+    <script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+    <style>
+.navbar-custom {
+  background-color: #c6d4e1;
+  border-size: 0px;
+  margin-bottom: 0px;
+  border-radius: 0px;
+}
+
+.navbar-custom .navbar-img-brand {
+  float: left;
+}
+
+.navbar-custom .navbar-img-brand img {
+  height: 47px;
+}
+
+.navbar-custom .navbar-brand {
+  color: #565c61;
+}
+.navbar-custom .navbar-brand:hover,
+.navbar-custom .navbar-brand:focus {
+  color: #3e4246;
+  background-color: transparent;
+}
+.navbar-custom .navbar-text {
+  color: #565c61;
+}
+.navbar-custom .navbar-nav > li > a {
+  color: #565c61;
+}
+.navbar-custom .navbar-nav > li > a:hover,
+.navbar-custom .navbar-nav > li > a:focus {
+  color: #333333;
+  background-color: transparent;
+}
+.navbar-custom .navbar-nav > .active > a,
+.navbar-custom .navbar-nav > .active > a:hover,
+.navbar-custom .navbar-nav > .active > a:focus {
+  color: #333333;
+  background-color: #b0c4d6;
+}
+.navbar-custom .navbar-nav > .disabled > a,
+.navbar-custom .navbar-nav > .disabled > a:hover,
+.navbar-custom .navbar-nav > .disabled > a:focus {
+  color: #cccccc;
+  background-color: transparent;
+}
+.navbar-custom .navbar-toggle {
+  border-color: #dddddd;
+}
+.navbar-custom .navbar-toggle:hover,
+.navbar-custom .navbar-toggle:focus {
+  background-color: #dddddd;
+}
+.navbar-custom .navbar-toggle .icon-bar {
+  background-color: #cccccc;
+}
+.navbar-custom .navbar-collapse,
+.navbar-custom .navbar-form {
+  border-color: #afc2d5;
+}
+.navbar-custom .navbar-nav > .dropdown > a:hover .caret,
+.navbar-custom .navbar-nav > .dropdown > a:focus .caret {
+  border-top-color: #333333;
+  border-bottom-color: #333333;
+}
+.navbar-custom .navbar-nav > .open > a,
+.navbar-custom .navbar-nav > .open > a:hover,
+.navbar-custom .navbar-nav > .open > a:focus {
+  background-color: #b0c4d6;
+  color: #333333;
+}
+.navbar-custom .navbar-nav > .open > a .caret,
+.navbar-custom .navbar-nav > .open > a:hover .caret,
+.navbar-custom .navbar-nav > .open > a:focus .caret {
+  border-top-color: #333333;
+  border-bottom-color: #333333;
+}
+.navbar-custom .navbar-nav > .dropdown > a .caret {
+  border-top-color: #565c61;
+  border-bottom-color: #565c61;
+}
+@media (max-width: 767) {
+  .navbar-custom .navbar-nav .open .dropdown-menu > li > a {
+    color: #565c61;
+  }
+  .navbar-custom .navbar-nav .open .dropdown-menu > li > a:hover,
+  .navbar-custom .navbar-nav .open .dropdown-menu > li > a:focus {
+    color: #333333;
+    background-color: transparent;
+  }
+  .navbar-custom .navbar-nav .open .dropdown-menu > .active > a,
+  .navbar-custom .navbar-nav .open .dropdown-menu > .active > a:hover,
+  .navbar-custom .navbar-nav .open .dropdown-menu > .active > a:focus {
+    color: #333333;
+    background-color: #b0c4d6;
+  }
+  .navbar-custom .navbar-nav .open .dropdown-menu > .disabled > a,
+  .navbar-custom .navbar-nav .open .dropdown-menu > .disabled > a:hover,
+  .navbar-custom .navbar-nav .open .dropdown-menu > .disabled > a:focus {
+    color: #cccccc;
+    background-color: transparent;
+  }
+}
+.navbar-custom .navbar-link {
+  color: #565c61;
+}
+.navbar-custom .navbar-link:hover {
+  color: #333333;
+}
+
+.bad-score {
+  color: #D70834;
+}
+
+thead .tname {
+  width: 60%;
+}
+thead .tpriority {
+  width: 20%;
+}
+
+thead .tscore {
+  width: 20%;
+}
+
+thead .cname {
+  width: 25%;
+}
+
+thead .cpriority {
+  width: 5%;
+}
+
+thead .ccorrection {
+  width: 70%;
+}
+
+.table-collapse {
+  display: inline;
+  font-size: 18px;
+  font-weight: bold;
+}
+
+.table-collapse a{
+  color: #333;
+}
+
+.table-collapse a:hover {
+  color: #777;
+  text-decoration: none;
+}
+
+.failures {
+  display: inline;
+}
+
+.label-as-badge {
+  border-radius: 1em;
+}
+    </style>
+
+  </head>
+  <body>
+  <header>
+      <nav class="navbar navbar-custom">
+        <div class="container">
+          <div class="navbar-header">
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#nb-collapse">
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-img-brand" href="http://ioos.noaa.gov/">
+              <img src="http://catalog.ioos.us/static/img/ioos.png" alt="IOOS Catalog" />
+            </a>
+            <div class="navbar-brand">
+              Compliance Checker
+            </div>
+          </div>
+      </nav>
+    </header>
+
+    <div class="container">
+    {% for check in checkers %}
+      <div class='check_wrapper'>{{ check }}</div>
+    {% endfor %}
+    </div>
+    <script type="text/javascript">
+$(document).ready(function() {
+    $('.high-priority-table').collapse({toggle: false});
+    $('.table-collapse').click(function(e) {
+      e.preventDefault();
+      // Find table to toggle within this check
+      var checkWrapper = $(e.target).closest(".check_wrapper");
+      $(checkWrapper).find('.' + $(e.target).data('target')).collapse('toggle');
+
+      var glyph = $(e.target).find('.glyphicon');
+      if(glyph.hasClass('glyphicon-collapse-up')) {
+        glyph.removeClass('glyphicon-collapse-up');
+        glyph.addClass('glyphicon-collapse-down');
+      } else {
+        glyph.removeClass('glyphicon-collapse-down');
+        glyph.addClass('glyphicon-collapse-up');
+      }
+    });
+});
+    </script>
+  </body>
+</html>

--- a/compliance_checker/runner.py
+++ b/compliance_checker/runner.py
@@ -119,16 +119,18 @@ class ComplianceChecker(object):
         @param ds_loc          Location of the source dataset
         @param limit           The degree of strictness, 1 being the strictest, and going up from there.
         '''
+        checkers_html = []
         for checker, rpair in score_groups.items():
             groups, errors = rpair
-            if output_filename == '-':
-                f = io.StringIO()
-                cs.html_output(checker, groups, f, ds_loc, limit)
-                f.seek(0)
-                print(f.read())
-            else:
-                with io.open(output_filename, 'w', encoding='utf8') as f:
-                    cs.html_output(checker, groups, f, ds_loc, limit)
+            checkers_html.append(cs.checker_html_output(checker, groups, ds_loc,
+                                                        limit))
+
+        html = cs.html_output(checkers_html)
+        if output_filename == '-':
+            print(html)
+        else:
+            with io.open(output_filename, 'w', encoding='utf8') as f:
+                f.write(html)
 
         return groups
 

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -275,14 +275,13 @@ class CheckSuite(object):
             return self.serialize(o.serialize())
         return o
 
-    def html_output(self, check_name, groups, file_object, source_name, limit):
+    def checker_html_output(self, check_name, groups, source_name, limit):
         '''
-        Renders an HTML file using Jinja2 and saves the output to the file specified.
+        Renders the HTML output for a single test using Jinja2 and returns it
+        as a string.
 
         @param check_name      The test which was run
         @param groups          List of results from compliance checker
-        @param output_filename Path to file to save output
-        @param file_object     A python file object where the output should be written to
         @param source_name     Source of the dataset, used for title
         @param limit           Integer value for limiting output
         '''
@@ -291,10 +290,19 @@ class CheckSuite(object):
         template = self.j2.get_template('ccheck.html.j2')
 
         template_vars = self.build_structure(check_name, groups, source_name, limit)
+        return template.render(**template_vars)
 
-        buf = template.render(**template_vars)
+    def html_output(self, checkers_html):
+        '''
+        Renders the HTML output for multiple tests and returns it as a string.
 
-        file_object.write(buf)
+        @param checkers_html     List of HTML for single tests as returned by
+                                 checker_html_output
+        '''
+        # Note: This relies on checker_html_output having been called so that
+        # self.j2 is initialised
+        template = self.j2.get_template('ccheck_wrapper.html.j2')
+        return template.render(checkers=checkers_html)
 
     def get_points(self, groups, limit):
         score_list = []


### PR DESCRIPTION
Previously only the last test to run would be shown in the HTML output. In fact, the results for each test would be written to the same output file sequentially, overwriting the results of the previous test.

For example, after running `checker.py -o output.html -f html --test cf --test acdd <dataset>`, `output.html` would only show results for the `acdd` test.

This change splits the HTML template into two files
* one with the header bar, CSS etc
* one to show the results of a single test

The second template is rendered for each test and included in the first.