### PR TITLE
Cleanup the list of available tests

### DIFF
--- a/cchecker.py
+++ b/cchecker.py
@@ -55,7 +55,7 @@ def main():
             version = getattr(check_suite.checkers[checker], '_cc_checker_version', "???")
             if args.verbose:
                 print(" - {} (v{})".format(checker, version))
-            elif ':' in checker and 'latest' not in checker:  # Skip the "latest" output
+            elif ':' in checker and not checker.endswith(':latest'):  # Skip the "latest" output
                 print(" - {}".format(checker))
         return 0
 

--- a/cchecker.py
+++ b/cchecker.py
@@ -50,10 +50,13 @@ def main():
         return 0
 
     if args.list_tests:
-        print("IOOS compliance checker available checker suites (code version):")
+        print("IOOS compliance checker available checker suites:")
         for checker in sorted(check_suite.checkers.keys()):
             version = getattr(check_suite.checkers[checker], '_cc_checker_version', "???")
-            print(" - {} ({})".format(checker, version))
+            if args.verbose:
+                print(" - {} (v{})".format(checker, version))
+            elif ':' in checker and 'latest' not in checker:  # Skip the "latest" output
+                print(" - {}".format(checker))
         return 0
 
     if args.download_standard_names:


### PR DESCRIPTION
This makes the list of tests much more tidy. 

```
$ python cchecker.py -l

IOOS compliance checker available checker suites:
 - acdd:1.1
 - acdd:1.3
 - cf:1.6
 - ioos:0.1
 - ioos:1.1
 - ioos_sos:0.1
```
Verbose option:

```
$ python cchecker.py -l -v

IOOS compliance checker available checker suites:
 - acdd (v3.1.1)
 - acdd:1.1 (v3.1.1)
 - acdd:1.3 (v3.1.1)
 - acdd:latest (v3.1.1)
 - cf (v3.1.1)
 - cf:1.6 (v3.1.1)
 - cf:latest (v3.1.1)
 - ioos (v3.1.1)
 - ioos:0.1 (v3.1.1)
 - ioos:1.1 (v3.1.1)
 - ioos:latest (v3.1.1)
 - ioos_sos (v3.1.1)
 - ioos_sos:0.1 (v3.1.1)
 - ioos_sos:latest (v3.1.1)
```