### PR TITLE
Remove scoring section from html and standard output

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,15 +23,15 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
-    - cmd: conda update --yes --quiet conda
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+    - cmd: conda.exe config --set always_yes yes --set changeps1 no --set show_channel_urls true
+    - cmd: conda.exe update conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --add channels conda-forge
-    - cmd: conda install --yes conda-build
-    - cmd: conda info
+    - cmd: conda.exe config --add channels conda-forge
+    - cmd: conda.exe install conda-build
+    - cmd: conda.exe info
 
 # Skip .NET project specific build phase.
 build: off

--- a/compliance_checker/acdd.py
+++ b/compliance_checker/acdd.py
@@ -125,7 +125,7 @@ class ACDDBaseCheck(BaseCheck):
                 self.applicable_variables.append(varname)
         return self.applicable_variables
 
-    @score_group('varattr')
+    @score_group('Variable Attributes')
     def check_var_long_name(self, ds):
         '''
         Checks each applicable variable for the long_name attribute
@@ -142,12 +142,12 @@ class ACDDBaseCheck(BaseCheck):
             long_name = getattr(ds.variables[variable], 'long_name', None)
             check = long_name is not None
             if not check:
-                msgs.append("Var %s missing attr long_name" % variable)
+                msgs.append("Var %s missing attribute long_name" % variable)
             results.append(Result(BaseCheck.HIGH, check, (variable, "var_std_name"), msgs))
 
         return results
 
-    @score_group('varattr')
+    @score_group('Variable Attributes')
     def check_var_standard_name(self, ds):
         '''
         Checks each applicable variable for the standard_name attribute
@@ -160,12 +160,12 @@ class ACDDBaseCheck(BaseCheck):
             std_name = getattr(ds.variables[variable], 'standard_name', None)
             check = std_name is not None
             if not check:
-                msgs.append("Var %s missing attr standard_name" % variable)
+                msgs.append("Var %s missing attribute standard_name" % variable)
             results.append(Result(BaseCheck.HIGH, check, (variable, "var_std_name"), msgs))
 
         return results
 
-    @score_group('varattr')
+    @score_group('Variable Attributes')
     def check_var_units(self, ds):
         '''
         Checks each applicable variable for the units attribute
@@ -183,14 +183,14 @@ class ACDDBaseCheck(BaseCheck):
                 continue
             # Check if we have no units
             if not unit_check:
-                msgs.append("Var %s missing attr units" % variable)
+                msgs.append("Var %s missing attribute units" % variable)
             results.append(Result(BaseCheck.HIGH, unit_check, (variable, "var_units"), msgs))
 
         return results
 
     def check_acknowledgment(self, ds):
         '''
-        Check if acknowledgment/acknowledgment attr is present.
+        Check if acknowledgment/acknowledgment attribute is present.
 
         :param netCDF4.Dataset ds: An open netCDF dataset
         '''
@@ -519,7 +519,7 @@ class ACDDBaseCheck(BaseCheck):
         # Conventions attribute is present, but does not include
         # proper ACDD version
         messages = [
-            "Attr Conventions does not contain 'ACDD-{}'".format(self._cc_spec_version)
+            "Global Attribute 'Conventions' does not contain 'ACDD-{}'".format(self._cc_spec_version)
         ]
         return ratable_result((1, 2),
                               'Conventions',
@@ -671,7 +671,7 @@ class ACDD1_3Check(ACDDNCCheck):
         return Result(BaseCheck.MEDIUM, date_created_check,
                       'date_created_is_iso', msgs)
 
-    @score_group('varattr')
+    @score_group('Variable Attributes')
     def check_var_coverage_content_type(self, ds):
         '''
         Check coverage content type against valid ISO-19115-1 codes
@@ -685,7 +685,7 @@ class ACDD1_3Check(ACDDNCCheck):
                             'coverage_content_type', None)
             check = ctype is not None
             if not check:
-                msgs.append("Var %s missing attr coverage_content_type" %
+                msgs.append("Var %s missing attribute coverage_content_type" %
                             variable)
                 results.append(Result(BaseCheck.HIGH, check,
                                       (variable, "coverage_content_type"),

--- a/compliance_checker/data/templates/ccheck.html.j2
+++ b/compliance_checker/data/templates/ccheck.html.j2
@@ -2,136 +2,150 @@
 <div class="row">
   <div class="col-md-12">
     <div class="page-header">
-      <h3>Your dataset scored {{scored_points}} out of {{possible_points}} points</h3>
-      <p>During the {{testname}} check</p>
+      <h2>IOOS Compliance Checker Report</h2>
       <p>For dataset {{source_name}}</p>
     </div>
   </div>
   <div class="col-md-12">
-    <h4>
-      Scoring Breakdown:
-    </h4>
+    <h3>{{testname}}</h3>
   </div>
   <div class="col-md-12">
-    <div class="table-collapse">
-      <a data-target="high-priority-table" href="#">High Priority <i class="glyphicon glyphicon-collapse-up"></i></a>
-    </div>
-    {% if high_count -%}
-    <div class="failures">
-      | <span class="label label-danger label-as-badge">{{ high_count }}</span>
-    </div>
-    {% endif -%}
-    <div class="high-priority-table collapse in">
-      <table class="table">
-        <thead>
-          <tr>
-            <th class="tname">Name</th>
-            <th class="tscore">Score</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for score in high_priorities -%}
-          {% if score['value'][0] < score['value'][1] -%}
-          <tr class="bad-score">
-          {% else -%}
-          <tr>
-          {% endif -%}
-
-            <td>{{score['name']}}</td>
-            <td>{{score['value'][0]}}/{{score['value'][1]}}</td>
-          </tr>
-          {% endfor -%}
-        </tbody>
-      </table>
-    </div> <!-- .high-priority-table -->
-  </div> <!-- .col-md-12 -->
-  <div class="col-md-12">
-    <div class="table-collapse">
-      <a data-target="medium-priority-table" href="#">Medium Priority <i class="glyphicon glyphicon-collapse-up"></i></a>
-    </div>
-    {% if medium_count -%}
-    <div class="failures">
-      | <span class="label label-danger label-as-badge">{{ medium_count }}</span>
-    </div>
-    {% endif -%}
-    <div class="medium-priority-table collapse in">
-      <table class="table">
-        <thead>
-          <tr>
-            <th class="tname">Name</th>
-            <th class="tscore">Score</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for score in medium_priorities -%}
-          {% if score['value'][0] < score['value'][1] -%}
-          <tr class="bad-score">
-          {% else -%}
-          <tr>
-          {% endif -%}
-
-            <td>{{score['name']}}</td>
-            <td>{{score['value'][0]}}/{{score['value'][1]}}</td>
-          </tr>
-          {% endfor -%}
-        </tbody>
-      </table>
-    </div> <!-- .medium-priority-table -->
-  </div> <!-- .col-md-12 -->
-  <div class="col-md-12">
-    <div class="table-collapse">
-      <a data-target="low-priority-table" href="#">Low Priority <i class="glyphicon glyphicon-collapse-up"></i></a>
-    </div>
-    {% if low_count -%}
-    <div class="failures">
-      | <span class="label label-danger label-as-badge">{{ low_count }}</span>
-    </div>
-    {% endif -%}
-    <div class="low-priority-table collapse in">
-      <table class="table">
-        <thead>
-          <tr>
-            <th class="tname">Name</th>
-            <th class="tscore">Score</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for score in low_priorities -%}
-          {% if score['value'][0] < score['value'][1] -%}
-          <tr class="bad-score">
-          {% else -%}
-          <tr>
-          {% endif -%}
-
-            <td>{{score['name']}}</td>
-            <td>{{score['value'][0]}}/{{score['value'][1]}}</td>
-          </tr>
-          {% endfor -%}
-        </tbody>
-      </table>
-    </div>
-  </div> <!-- .col-md-12 -->
-  <div class="col-md-12">
     <h4>Corrective Actions</h4>
-    <table class="table">
-      <thead>
-        <tr>
-          <th class="cname">Name</td>
-          <th class="cpriority">Priority</td>
-          <th class="ccorrection">Corrective action</td>
-        </tr>
-      </thead>
-      <tbody>
-      {% for result in all_priorities -%}
-        {% for msg in result['msgs']-%}
-          <tr>
-            <td>{{result['name']}}</td>
-            <td>{{result['weight']}}</td>
-            <td>{{msg}}</td>
-          </tr>
-        {% endfor -%}
-      {% endfor -%}
-      </tbody>
-    </table>
+    <div class="col-md-12">
+      <div class="table-collapse">
+        <a data-target="high-priority-table" href="#">High Priority <i class="glyphicon glyphicon-collapse-up"></i></a>
+      </div>
+      {% if high_count -%}
+      <div class="failures">
+        | <span class="label label-danger label-as-badge">{{ high_count }}</span>
+      </div>
+      <div class="high-priority-table collapse in">
+        <table class="table">
+          <thead>
+            <tr>
+              <th class="cname">Name</th>
+              <th class="ccorrection">Reasoning</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for result in all_priorities -%}
+              {% if result['weight'] == 3 -%}
+                {% for msg in result['msgs']-%}
+                  <tr>
+                    <td>{{result['name']}}</td>
+                    <td>{{msg}}</td>
+                  </tr>
+                {% endfor -%}
+              {% endif -%}
+            {% endfor -%}
+          </tbody>
+        </table>
+      </div> <!-- .high-priority-table -->
+      {% else -%}
+      <div class="failures">
+        | <span class="label label-success label-as-badge">{{ high_count }}</span>
+      </div>
+
+      <div class="high-priority-table collapse in">
+        <table class="table">
+          <tbody>
+            <tr>
+              <td>All high priority checks passed!</th>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      {% endif -%}
+    </div> <!-- .col-md-12 -->
+    <div class="col-md-12">
+      <div class="table-collapse">
+        <a data-target="medium-priority-table" href="#">Medium Priority <i class="glyphicon glyphicon-collapse-up"></i></a>
+      </div>
+      {% if medium_count -%}
+      <div class="failures">
+        | <span class="label label-danger label-as-badge">{{ medium_count }}</span>
+      </div>
+      <div class="medium-priority-table collapse in">
+        <table class="table">
+          <thead>
+            <tr>
+              <th class="cname">Name</th>
+              <th class="ccorrection">Reasoning</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for result in all_priorities -%}
+              {% if result['weight'] == 2 -%}
+                {% for msg in result['msgs']-%}
+                  <tr>
+                    <td>{{result['name']}}</td>
+                    <td>{{msg}}</td>
+                  </tr>
+                {% endfor -%}
+              {% endif -%}
+            {% endfor -%}
+          </tbody>
+        </table>
+      </div> <!-- .medium-priority-table -->
+      {% else -%}
+      <div class="failures">
+        | <span class="label label-success label-as-badge">{{ medium_count }}</span>
+      </div>
+      <div class="medium-priority-table collapse in">
+        <table class="table">
+          <tbody>
+            <tr>
+              <td>All medium priority checks passed!</th>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      {% endif -%}
+    </div> <!-- .col-md-12 -->
+    <div class="col-md-12">
+      <div class="table-collapse">
+        <a data-target="low-priority-table" href="#">Low Priority <i class="glyphicon glyphicon-collapse-up"></i></a>
+      </div>
+      {% if low_count -%}
+      <div class="failures">
+        | <span class="label label-danger label-as-badge">{{ low_count }}</span>
+      </div>
+      <div class="low-priority-table collapse in">
+        <table class="table">
+          <thead>
+            <tr>
+              <th class="cname">Name</th>
+              <th class="ccorrection">Reasoning</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for result in all_priorities -%}
+              {% if result['weight'] == 1 -%}
+                {% for msg in result['msgs']-%}
+                  <tr>
+                    <td>{{result['name']}}</td>
+                    <td>{{msg}}</td>
+                  </tr>
+                {% endfor -%}
+              {% endif -%}
+            {% endfor -%}
+          </tbody>
+        </table>
+      </div> <!-- .low-priority-table -->
+      {% else -%}
+      <div class="failures">
+        | <span class="label label-success label-as-badge">{{ low_count }}</span>
+      </div>
+      <div class="low-priority-table collapse in">
+        <table class="table">
+          <tbody>
+            <tr>
+              <td>All low priority checks passed!</th>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      {% endif -%}
+    </div> <!-- .col-md-12 -->
   </div> <!-- .col-md-12 -->
 </div> <!-- .row -->

--- a/compliance_checker/runner.py
+++ b/compliance_checker/runner.py
@@ -103,10 +103,7 @@ class ComplianceChecker(object):
         for checker, rpair in score_groups.items():
             groups, errors = rpair
             score_list, points, out_of = cs.standard_output(limit, checker, groups)
-            if not verbose:
-                cs.non_verbose_output_generation(score_list, groups, limit, points, out_of)
-            else:
-                cs.verbose_output_generation(groups, limit, points, out_of)
+            cs.standard_output_generation(groups, limit, points, out_of)
         return groups
 
     @classmethod

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -36,6 +36,9 @@ class CheckSuite(object):
 
     checkers = {}       # Base dict of checker names to BaseCheck derived types, override this in your CheckSuite implementation
 
+    def __init__(self):
+        self.col_width = 80
+
     @classmethod
     def load_all_available_checkers(cls):
         """
@@ -332,93 +335,23 @@ class CheckSuite(object):
         score_list, points, out_of = self.get_points(groups, limit)
         print('\n')
         print("-" * 80)
-        print('{:^80}'.format("The dataset scored %r out of %r points" % (points, out_of)))
-        print('{:^80}'.format("during the %s check" % check_name))
+        print('{:^80}'.format("IOOS Compliance Checker Report"))
+        print('{:^80}'.format("%s check" % check_name))
         print("-" * 80)
 
         return [score_list, points, out_of]
 
-    def non_verbose_output_generation(self, score_list, groups, limit, points, out_of):
-
+    def standard_output_generation(self, groups, limit, points, out_of):
+        '''
+        Generates the Terminal Output
+        '''
         if points < out_of:
-            print('{:^80}'.format("Scoring Breakdown:"))
-            print('\n')
-            priority_flag = 3
-            for x in range(len(score_list)):
-                if score_list[x][1] == 3 and limit <= 3:
-                    if priority_flag == 3:
-                        print('{:^80}'.format("High Priority"))
-                        print("-" * 80)
-                        print('%-36s:%8s:%6s' % ('    Name', 'Priority', 'Score'))
-                        priority_flag -= 1
-                    print('%-40s:%s:%6s/%1s' % (score_list[x][0][0:39], score_list[x][1], score_list[x][2][0], score_list[x][2][1]))
-
-                elif score_list[x][1] == 2 and limit <= 2:
-                    if priority_flag == 2:
-                        print('\n')
-                        print('{:^80}'.format("Medium Priority"))
-                        print("-" * 80)
-                        print('%-36s:%8s:%6s' % ('    Name', 'Priority', 'Score'))
-                        priority_flag -= 1
-                    print('%-40s:%s:%6s/%1s' % (score_list[x][0][0:39], score_list[x][1], score_list[x][2][0], score_list[x][2][1]))
-
-                elif score_list[x][1] == 1 and limit == 1:
-                    if priority_flag == 1:
-                        print('\n')
-                        print('{:^80}'.format("Low Priority"))
-                        print("-" * 80)
-                        print('%-36s:%8s:%6s' % ('    Name', 'Priority', 'Score'))
-                        priority_flag -= 1
-                    print('%-40s:%s:%6s/%1s' % (score_list[x][0][0:39], score_list[x][1], score_list[x][2][0], score_list[x][2][1]))
-
-                elif score_list[x][1] == 1 and limit == 1 and priority_flag == 2:
-                    print('{:^80}'.format('No medium priority tests present'))
-                    print('-' * 80)
-                    priority_flag -= 1
-            # Catch All for pretty presentation
-            if priority_flag == 2 and limit == 2:
-                print('{:^80}'.format('No Medium priority tests present'))
-                print('-' * 80)
-
-            if priority_flag == 2 and limit == 1:
-                print('{:^80}'.format('No Medium priority tests present'))
-                print('-' * 80)
-                print('')
-                print('{:^80}'.format('No Low priority tests present'))
-                print('-' * 80)
-
-            if priority_flag == 1 and limit == 1:
-                print('{:^80}'.format('No Low priority tests present'))
-                print('-' * 80)
-
-            print("\n" + "\n" + '-' * 80)
-            print('{:^80}'.format('Reasoning for the failed tests given below:'))
-            print('\n')
-            print('%s%37s:%10s:%8s' % ('Name', 'Priority', '  Score', 'Reasoning'))
-            print("-" * 80)
+            # print("\n" + "\n" + '-' * 80)
             self.reasoning_routine(groups, 0)
-
         else:
             print("All tests passed!")
 
-    def verbose_output_generation(self, groups, limit, points, out_of):
-        '''
-        Generates the Terminal Output for Verbose cases
-        '''
-        priority_flag = 3
-        print('{:^80}'.format("Verbose Scoring Breakdown:"), end=' ')
-        self.print_routine(groups, 0, priority_flag)
-        if points < out_of:
-            print("\n" + "\n" + '-' * 80)
-            print('{:^80}'.format('Reasoning for the failed tests given below:'))
-            print('\n')
-            print('%s%37s:%10s:%8s' % ('Name', 'Priority', '  Score', 'Reasoning'))
-            print("-" * 80)
-            self.reasoning_routine(groups, 0)
-
-        pass
-
-    def print_routine(self, list_of_results, indent, priority_flag):
+    def reasoning_routine(self, list_of_results, indent, line=True, priority_flag=3):
         """
         print routine performed
         """
@@ -427,64 +360,44 @@ class CheckSuite(object):
             Function that returns the weight, used for sorting by priority
             """
             return r.weight
-
-        # Sorting method used to properly sort the output by priority.
-        grouped_sorted = []
-        grouped_sorted = sorted(list_of_results, key=weight_func, reverse=True)
-
-        # Loop over input
-        for res in grouped_sorted:
-            # If statements to print the proper Headings
-            if res.weight == 3 and indent == 0 and priority_flag == 3:
-                print('\n')
-                print('{:^80}'.format("High Priority"))
-                print("-" * 80)
-                print('%-36s:%8s:%6s' % ('    Name', 'Priority', 'Score'))
-
-                priority_flag -= 1
-            if res.weight == 2 and indent == 0 and priority_flag == 2:
-                print('\n')
-                print('{:^80}'.format("Medium Priority"))
-                print("-" * 80)
-                print('%-36s:%8s:%6s' % ('    Name', 'Priority', 'Score'))
-
-                priority_flag -= 1
-            if res.weight == 1 and indent == 0 and priority_flag == 1:
-                print('\n')
-                print('{:^80}'.format("Low Priority"))
-                print("-" * 80)
-                print('%-36s:%8s:%6s' % ('    Name', 'Priority', 'Score'))
-                priority_flag -= 1
-
-            print('%-40s:%s:%s%6s/%1s' % ((indent * '    ' + res.name)[0:39], res.weight, indent * '  ', res.value[0], res.value[1]))
-            if res.children:
-                self.print_routine(res.children, indent + 1, priority_flag)
-
-    def reasoning_routine(self, list_of_results, indent, line=True):
-        """
-        print routine performed
-        """
-        def weight_func(r):
-            """
-            Function that returns the weight, used for sorting by priority
-            """
-            return r.weight
-
         # Sorting method used to properly sort the output by priority.
         grouped_sorted = []
         grouped_sorted = sorted(list_of_results, key=weight_func, reverse=True)
 
         wrapper = textwrap.TextWrapper(initial_indent='', width=80, subsequent_indent=' ' * 54)
         for res in grouped_sorted:
+            # If statements to print the proper Headings
+            if res.weight == 3 and indent == 0 and priority_flag == 3:
+                print('\n')
+                print('{:^80}'.format("High Priority"))
+                print("-" * 80)
+                print('%-39s:%6s' % ('    Name', ' Reasoning'))
+                print("-" * 80)
+
+                priority_flag -= 1
+            if res.weight == 2 and indent == 0 and priority_flag == 2:
+                print('\n')
+                print('{:^80}'.format("Medium Priority"))
+                print("-" * 80)
+                print('%-39s:%6s' % ('    Name', ' Reasoning'))
+                print("-" * 80)
+
+                priority_flag -= 1
+            if res.weight == 1 and indent == 0 and priority_flag == 1:
+                print('\n')
+                print('{:^80}'.format("Low Priority"))
+                print("-" * 80)
+                print('%-39s:%6s' % ('    Name', ' Reasoning'))
+                print("-" * 80)
+                priority_flag -= 1
+
             if (res.value[0] != res.value[1]) and not res.msgs:
-                print('%-39s:%1s:%6s/%2s : %s' % ((indent * '    ' + res.name)[0:39], res.weight, res.value[0], res.value[1], ' '))
+                print('%-39s' %
+                      ((indent * '    ' + res.name)[0:39]))
 
             if (res.value[0] != res.value[1]) and res.msgs:
-                print(wrapper.fill('%-39s:%1s:%6s/%2s : %s' %
+                print(wrapper.fill('%-39s: %s' %
                       ((indent * '    ' + res.name)[0:39],
-                       res.weight,
-                       res.value[0],
-                       res.value[1],
                        ", ".join(res.msgs))))
 
             if res.children:

--- a/compliance_checker/tests/test_suite.py
+++ b/compliance_checker/tests/test_suite.py
@@ -52,7 +52,7 @@ class TestSuite(unittest.TestCase):
             groups, errors = rpair
             score_list, points, out_of = cs.standard_output(limit, checker, groups)
             # This asserts that print is able to generate all of the unicode output
-            cs.non_verbose_output_generation(score_list, groups, limit, points, out_of)
+            cs.standard_output_generation(groups, limit, points, out_of)
 
     def test_skip_checks(self):
         """Tests that checks are properly skipped when specified"""
@@ -77,7 +77,7 @@ class TestSuite(unittest.TestCase):
             groups, errors = rpair
             score_list, points, out_of = cs.standard_output(limit, checker, groups)
             # This asserts that print is able to generate all of the unicode output
-            cs.non_verbose_output_generation(score_list, groups, limit, points, out_of)
+            cs.standard_output_generation(groups, limit, points, out_of)
 
     def test_score_grouping(self):
         # Testing the grouping of results for output, which can fail
@@ -111,7 +111,7 @@ class TestSuite(unittest.TestCase):
             groups, errors = rpair
             score_list, cdl_points, cdl_out_of = cs.standard_output(limit, checker, groups)
             # This asserts that print is able to generate all of the unicode output
-            cs.non_verbose_output_generation(score_list, groups, limit, cdl_points, cdl_out_of)
+            cs.standard_output_generation(groups, limit, cdl_points, cdl_out_of)
         ds.close()
 
         # Ok now load the nc file that it came from
@@ -123,7 +123,7 @@ class TestSuite(unittest.TestCase):
             groups, errors = rpair
             score_list, nc_points, nc_out_of = cs.standard_output(limit, checker, groups)
             # This asserts that print is able to generate all of the unicode output
-            cs.non_verbose_output_generation(score_list, groups, limit, nc_points, nc_out_of)
+            cs.standard_output_generation(groups, limit, nc_points, nc_out_of)
         ds.close()
 
         nc_file_path = static_files['test_cdl'].replace('.cdl', '.nc')
@@ -137,4 +137,4 @@ class TestSuite(unittest.TestCase):
         cs = CheckSuite()
         resp = cs.load_local_dataset(static_files['empty'])
         assert isinstance(resp, GenericFile) ==  True
-        
+


### PR DESCRIPTION
@benjwadams this is going into the refactor-scoring branch. This PR simply removes the scoring section of the output (html and standard output, json is unchanged) as a starting point. What's left is the reasoning section that is now divided into the high, medium and low priorities.