### PR TITLE
Move Suite.get_priority_headers into Checker based class attributes

### DIFF
--- a/compliance_checker/acdd.py
+++ b/compliance_checker/acdd.py
@@ -25,6 +25,11 @@ class ACDDBaseCheck(BaseCheck):
     _cc_spec = 'acdd'
     _cc_description = 'Attribute Conventions for Dataset Discovery (ACDD)'
     _cc_url = 'http://wiki.esipfed.org/index.php?title=Category:Attribute_Conventions_Dataset_Discovery'
+    _cc_display_headers = {
+        3: 'Highly Recommended',
+        2: 'Recommended',
+        1: 'Suggested'
+    }
 
     def __init__(self):
 

--- a/compliance_checker/base.py
+++ b/compliance_checker/base.py
@@ -42,6 +42,11 @@ class BaseCheck(object):
     LOW    = 1
 
     _cc_checker_version = __version__
+    _cc_display_headers = {
+        3: 'High Priority',
+        2: 'Medium Priority',
+        1: 'Low Priority'
+    }
 
     supported_ds = []
 

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -61,6 +61,11 @@ class CFBaseCheck(BaseCheck):
     _cc_spec_version = '1.6'
     _cc_description = 'Climate and Forecast Conventions (CF)'
     _cc_url = 'http://cfconventions.org'
+    _cc_display_headers = {
+        3: 'Errors',
+        2: 'Warnings',
+        1: 'Info'
+    }
 
     """
     CF Convention Checker (1.6)

--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -14,6 +14,11 @@ class IOOSBaseCheck(BaseCheck):
     _cc_spec_version = '0.1'
     _cc_description = 'IOOS Inventory Metadata'
     _cc_url = 'https://ioos.github.io/ioos-netcdf/ioos-netcdf-metadata-description-v1-1.html#ioos-netcdf-metadata-profile-attributes'
+    _cc_display_headers = {
+        3: 'Highly Recommended',
+        2: 'Recommended',
+        1: 'Suggested'
+    }
 
     @classmethod
     def _has_attr(cls, ds, attr, concept_name, priority=BaseCheck.HIGH):

--- a/compliance_checker/runner.py
+++ b/compliance_checker/runner.py
@@ -103,7 +103,7 @@ class ComplianceChecker(object):
         for checker, rpair in score_groups.items():
             groups, errors = rpair
             score_list, points, out_of = cs.standard_output(limit, checker, groups)
-            cs.standard_output_generation(groups, limit, points, out_of, check=checker)
+            cs.standard_output_generation(groups, limit, points, out_of, checker)
         return groups
 
     @classmethod

--- a/compliance_checker/tests/test_suite.py
+++ b/compliance_checker/tests/test_suite.py
@@ -52,7 +52,7 @@ class TestSuite(unittest.TestCase):
             groups, errors = rpair
             score_list, points, out_of = cs.standard_output(limit, checker, groups)
             # This asserts that print is able to generate all of the unicode output
-            cs.standard_output_generation(groups, limit, points, out_of, check=checker)
+            cs.standard_output_generation(groups, limit, points, out_of, checker)
 
     def test_skip_checks(self):
         """Tests that checks are properly skipped when specified"""
@@ -77,7 +77,7 @@ class TestSuite(unittest.TestCase):
             groups, errors = rpair
             score_list, points, out_of = cs.standard_output(limit, checker, groups)
             # This asserts that print is able to generate all of the unicode output
-            cs.standard_output_generation(groups, limit, points, out_of, check=checker)
+            cs.standard_output_generation(groups, limit, points, out_of, checker)
 
     def test_score_grouping(self):
         # Testing the grouping of results for output, which can fail
@@ -111,7 +111,7 @@ class TestSuite(unittest.TestCase):
             groups, errors = rpair
             score_list, cdl_points, cdl_out_of = cs.standard_output(limit, checker, groups)
             # This asserts that print is able to generate all of the unicode output
-            cs.standard_output_generation(groups, limit, cdl_points, cdl_out_of, check=checker)
+            cs.standard_output_generation(groups, limit, cdl_points, cdl_out_of, checker)
         ds.close()
 
         # Ok now load the nc file that it came from
@@ -123,7 +123,7 @@ class TestSuite(unittest.TestCase):
             groups, errors = rpair
             score_list, nc_points, nc_out_of = cs.standard_output(limit, checker, groups)
             # This asserts that print is able to generate all of the unicode output
-            cs.standard_output_generation(groups, limit, nc_points, nc_out_of, check=checker)
+            cs.standard_output_generation(groups, limit, nc_points, nc_out_of, checker)
         ds.close()
 
         nc_file_path = static_files['test_cdl'].replace('.cdl', '.nc')


### PR DESCRIPTION
To prevent staleness and allow 3rd party plugins to override priority names, a new class attribute (`_cc_display_headers`) is introduced mapping priority names to display strings.  If not defined in the derived checker, the base ones are used.

- create _cc_display_headers attr in each Checker
- make checker name a required positional argument where used

Will need to be done in the NCEI suite of checkers too (I can do this if no one else can get to it, but tell me).
