### PR TITLE
Fix #562 duplicate axis coordinates

### DIFF
--- a/compliance_checker/cfutil.py
+++ b/compliance_checker/cfutil.py
@@ -677,20 +677,6 @@ def get_axis_map(ds, variable):
             if coord_name not in axis_map[axis]:
                 axis_map[axis].append(coord_name)
 
-    # Sometimes dimensionless coordinates are considered coordinate variables.
-    # I know, it's confusing.
-    if 'X' not in axis_map and longitudes:
-        axis_map['X'] = longitudes
-
-    if 'Y' not in axis_map and latitudes:
-        axis_map['Y'] = latitudes
-
-    if 'T' not in axis_map and times:
-        axis_map['T'] = times
-
-    if 'Z' not in axis_map and heights:
-        axis_map['Z'] = heights
-
     return axis_map
 
 

--- a/compliance_checker/tests/test_feature_detection.py
+++ b/compliance_checker/tests/test_feature_detection.py
@@ -283,8 +283,9 @@ class TestFeatureDetection(TestCase):
 
             axis_map = util.get_axis_map(nc, 'temperature')
             assert axis_map['T'] == ['time']
-            assert axis_map['Y'] == ['lat']
-            assert axis_map['X'] == ['lon']
+            assert axis_map['Z'] == []
+            assert axis_map['Y'] == []
+            assert axis_map['X'] == []
 
         with Dataset(resources.STATIC_FILES['index_ragged']) as nc:
             assert util.guess_feature_type(nc, 'temperature') == "single-trajectory"
@@ -300,7 +301,7 @@ class TestFeatureDetection(TestCase):
 
             axis_map = util.get_axis_map(nc, 'sea_surface_height')
             assert axis_map['T'] == ['time']
-            assert axis_map['Z'] == ['z']
+            assert axis_map['Z'] == []
             assert axis_map['Y'] == ['lat']
             assert axis_map['X'] == ['lon']
 


### PR DESCRIPTION
This proposed solution fixes the problem I reported in #562 for that particular test files. The change makes sense to me because I don't really understand the logic behind the lines that I've removed. However, there may be a good reason to keep them! I'm just putting this up for discussion and review.

This broke one unittest:
compliance_checker/tests/test_feature_detection.py::TestFeatureDetection::test_global_feature_detection
I have updated this test so that it now passes.