### PR TITLE
Fix CF dimension order check

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -674,7 +674,7 @@ class CFBaseCheck(BaseCheck):
         :return: Returns True if the dimensions are in order U*, T, Z, Y, X,
                  False otherwise
         '''
-        regx = regex.compile(r'^L?I?U*T?Z?(?:(?:Y?X?)|(?:C?)|(?:A+))$')
+        regx = regex.compile(r'^[^TZYX]*T?Z?Y?X?$')
         dimension_string = ''.join(dimension_order)
         return regx.match(dimension_string) is not None
 

--- a/compliance_checker/tests/data/dimension_order.cdl
+++ b/compliance_checker/tests/data/dimension_order.cdl
@@ -1,0 +1,41 @@
+netcdf dimension_order {
+dimensions:
+    TIME = 4 ;
+    INSTRUMENT = 2 ;
+variables:
+    double TIME(TIME) ;
+        TIME:axis = "T" ;
+        TIME:standard_name = "time" ;
+        TIME:units = "days since 1970-01-01T00:00:00 UTC" ;
+    float NOMINAL_DEPTH(INSTRUMENT);
+        NOMINAL_DEPTH:axis = "Z" ;
+        NOMINAL_DEPTH:positive = "down" ;
+        NOMINAL_DEPTH:standard_name = "depth" ;
+        NOMINAL_DEPTH:units = "m" ;
+    float LATITUDE ;
+        LATITUDE:axis = "Y" ;
+        LATITUDE:standard_name = "latitude" ;
+        LATITUDE:units = "degrees_north" ;
+    float LONGITUDE ;
+        LONGITUDE:axis = "X" ;
+        LONGITUDE:standard_name = "longitude" ;
+        LONGITUDE:units = "degrees_east" ;
+    float TEMP(INSTRUMENT, TIME) ;
+        TEMP:standard_name = "sea_water_temperature" ;
+        TEMP:units = "degrees_Celsius" ;
+        TEMP:coordinates = "TIME NOMINAL_DEPTH LATITUDE LONGITUDE" ;
+
+data:
+
+ TIME = 24608.65, 24608.66, 24608.67, 24608.68 ;
+
+ NOMINAL_DEPTH = 22, 107 ;
+
+ LATITUDE = -27.3415 ;
+
+ LONGITUDE = 153.5619 ;
+
+ TEMP = 21.20, 21.21, 21.21, 21.21,
+        12.01, 12.05, 12.08, 12.03 ;
+
+}

--- a/compliance_checker/tests/resources.py
+++ b/compliance_checker/tests/resources.py
@@ -113,4 +113,5 @@ STATIC_FILES = {
     'bad_cell_measure2'                    : get_filename('tests/data/bad_cell_measure2.cdl'),
     'bad_cf_role'                          : get_filename('tests/data/bad_cf_role.cdl'),
     'ioos_gold_1_1'                        : get_filename('tests/data/ioos_1_1.cdl'),
+    'dimension_order'                      : get_filename('tests/data/dimension_order.cdl')
 }

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -173,6 +173,11 @@ class TestCF(BaseTestCase):
         assert result.msgs[0] == ("really_bad's dimensions are not in the recommended order "
                                   "T, Z, Y, X. They are latitude, power")
 
+        dataset = self.load_dataset(STATIC_FILES['dimension_order'])
+        result = self.cf.check_dimension_order(dataset)
+        self.assertEqual((3, 3), result.value)
+        self.assertEqual([], result.msgs)
+
     def test_check_fill_value_outside_valid_range(self):
         """
         2.5.1 The _FillValue should be outside the range specified by valid_range (if used) for a variable.


### PR DESCRIPTION
Fixes #535, at least for the specific example I encountered.

I have simplified the regular expression used to check the dimension order, so this might change the return value of this check for other data sets. However, based on [CF section 2.4](http://cfconventions.org/cf-conventions/v1.6.0/cf-conventions.html#dimensions), which this check is implementing, I don't see why there is a need for a more complicated regex than what I have put here.

In particular, I don't see why the previous version allows dimensions other than "X" at the end of the list of dimensions?