### PR TITLE
pin packages until cf_units 2.0 is released

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 OWSLib>=0.8.3
 lxml>=3.2.1
-cf_units>=0.1.1
+cf_units>=0.1.1,<2
 requests>=2.2.1
 isodate>=0.5.4
 Jinja2>=2.7.3
 setuptools>=15.0
 pygeoif>=0.6
-netCDF4>=1.3.0
+netCDF4>=1.3.0,<1.4
 regex==2017.07.28
 pendulum>=1.2.4
 tabulate==0.8.2


### PR DESCRIPTION
I can fix the conda-forge package without a new release but PyPI users will need a new release to get this change.

We need to revert that once `cf_units 2.0` is released. It should be out next week or so.

PS: there is one test failure and I think it is unrelated to this change. Can you double check that @Bobfrat?