### PR TITLE
from int to np.signedinteger is deprecated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -2483,9 +2483,12 @@ class CFBaseCheck(BaseCheck):
             valid_region = TestCtx(BaseCheck.MEDIUM,
                                    "§6.1.1 Geographic region specified by {} is valid"
                                    "".format(var.name))
-            valid_region.assert_true(''.join(var[:].astype(str)).lower() in region_list,
+            region = var[:]
+            if np.ma.isMA(region):
+                region = region.data
+            valid_region.assert_true(''.join(region.astype(str)).lower() in region_list,
                                      "{} is not a valid region"
-                                     "".format(''.join(var[:].astype(str))))
+                                     "".format(''.join(region.astype(str))))
             ret_val.append(valid_region.to_result())
         return ret_val
 

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -1348,7 +1348,7 @@ class CFBaseCheck(BaseCheck):
                                 "flag_masks ({}) mustbe the same data type as {} ({})"
                                 "".format(flag_masks.dtype, name, variable.dtype))
 
-        type_ok = (np.issubdtype(variable.dtype, int) or
+        type_ok = (np.issubdtype(variable.dtype, np.integer) or
                    np.issubdtype(variable.dtype, 'S') or
                    np.issubdtype(variable.dtype, 'b'))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 OWSLib>=0.8.3
 lxml>=3.2.1
-cf_units>=0.1.1
+cf_units>=0.1.1,<2
 requests>=2.2.1
 isodate>=0.5.4
 Jinja2>=2.7.3
 setuptools>=15.0
 pygeoif>=0.6
-netCDF4>=1.3.0
+netCDF4>=1.3.0,<1.4
 regex==2017.07.28
 pendulum>=1.2.4
 tabulate==0.8.2


### PR DESCRIPTION
This fixes the `FutureWarning` we are from latest `numpy`

```
compliance_checker/tests/test_cf.py::TestCF::test_check_flag_masks
  /home/travis/build/ocefpaf/compliance-checker/compliance_checker/cf/cf.py:1351: FutureWarning: Conversion of the second argument of issubdtype from `int` to `np.signedinteger` is deprecated. In future, it will be treated as `np.int64 == np.dtype(int).type`.
    type_ok = (np.issubdtype(variable.dtype, int) or
```