### PR TITLE
use cf_units 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 OWSLib>=0.8.3
 lxml>=3.2.1
-cf_units>=0.1.1,<2
+cf_units>=2
 requests>=2.2.1
 isodate>=0.5.4
 Jinja2>=2.7.3
 setuptools>=15.0
 pygeoif>=0.6
-netCDF4>=1.3.0,<1.4
+netCDF4>=1.4.0
 regex==2017.07.28
 pendulum>=1.2.4
 tabulate==0.8.2


### PR DESCRIPTION
This will use the latest `cftime`, which was bundled in `netcdf4` as `netcdftime` before. In theory there should be no code breakages in `compliance-checker`.

PS: it would be nice to get a new micro point release so people can get udpated `netcdf4` packages on their systems.