### PR TITLE
Uses set instead of list types for CF coord var tests

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -1046,7 +1046,7 @@ class CFBaseCheck(BaseCheck):
         # UDunits can't tell the difference between east and north facing coordinates
         elif standard_name == 'latitude':
             # degrees is allowed if using a transformed grid
-            allowed_units = cfutil.VALID_LAT_UNITS + ['degrees']
+            allowed_units = cfutil.VALID_LAT_UNITS | {'degrees'}
             valid_standard_units.assert_true(units.lower() in allowed_units,
                                              'variables defining latitude must use degrees_north '
                                              'or degrees if defining a transformed grid. Currently '
@@ -1054,7 +1054,7 @@ class CFBaseCheck(BaseCheck):
         # UDunits can't tell the difference between east and north facing coordinates
         elif standard_name == 'longitude':
             # degrees is allowed if using a transformed grid
-            allowed_units = cfutil.VALID_LON_UNITS + ['degrees']
+            allowed_units = cfutil.VALID_LON_UNITS | {'degrees'}
             valid_standard_units.assert_true(units.lower() in allowed_units,
                                              'variables defining longitude must use degrees_east '
                                              'or degrees if defining a transformed grid. Currently '
@@ -1537,7 +1537,7 @@ class CFBaseCheck(BaseCheck):
             # Check that latitude uses allowed units
             allowed_units = TestCtx(BaseCheck.MEDIUM, '§4.1 Latitude variable {} uses recommended units'.format(latitude))
             if standard_name == 'grid_latitude':
-                e_n_units = cfutil.VALID_LAT_UNITS + cfutil.VALID_LON_UNITS
+                e_n_units = cfutil.VALID_LAT_UNITS | cfutil.VALID_LON_UNITS
                 # check that the units aren't in east and north degrees units,
                 # but are convertible to angular units
                 allowed_units.assert_true(units not in e_n_units and
@@ -1631,7 +1631,7 @@ class CFBaseCheck(BaseCheck):
             # Check that longitude uses allowed units
             allowed_units = TestCtx(BaseCheck.MEDIUM, '§4.1 Longitude variable {} uses recommended units'.format(longitude))
             if standard_name == 'grid_longitude':
-                e_n_units = cfutil.VALID_LAT_UNITS + cfutil.VALID_LON_UNITS
+                e_n_units = cfutil.VALID_LAT_UNITS | cfutil.VALID_LON_UNITS
                 # check that the units aren't in east and north degrees units,
                 # but are convertible to angular units
                 allowed_units.assert_true(units not in e_n_units and

--- a/compliance_checker/cfutil.py
+++ b/compliance_checker/cfutil.py
@@ -19,26 +19,26 @@ except NameError:
 _UNITLESS_DB = None
 _SEA_NAMES = None
 
-VALID_LAT_UNITS = [
+VALID_LAT_UNITS = {
     'degrees_north',
     'degree_north',
     'degree_n',
     'degrees_n',
     'degreen',
     'degreesn'
-]
-VALID_LON_UNITS = [
+}
+VALID_LON_UNITS = {
     'degrees_east',
     'degree_east',
     'degree_e',
     'degrees_e',
     'degreee',
     'degreese'
-]
+}
 
 
 # We can't import appendix d without getting circular imports
-DIMENSIONLESS_VERTICAL_COORDINATES = [
+DIMENSIONLESS_VERTICAL_COORDINATES = {
     'ocean_s_coordinate',
     'ocean_s_coordinate_g1',
     'ocean_s_coordinate_g2',
@@ -50,7 +50,7 @@ DIMENSIONLESS_VERTICAL_COORDINATES = [
     'atmosphere_sigma_coordinate',
     'atmosphere_ln_pressure_coordinate',
     'atmosphere_sleve_coordinate'
-]
+}
 
 
 def get_unitless_standard_names(xml_tree, units):
@@ -120,7 +120,8 @@ def is_geophysical(ds, variable):
     unitless = is_unitless(ds, variable)
 
     # Is the standard name associated with coordinates
-    if standard_name in ('time', 'latitude', 'longitude', 'height', 'depth', 'altitude'):
+    if standard_name in {'time', 'latitude', 'longitude',
+                         'height', 'depth', 'altitude'}:
         return False
 
     if variable in get_coordinate_variables(ds):


### PR DESCRIPTION
Uses set types for membership tests against possible names of various
coordinates.  This will possibly speed the code up a little bit since
set membership is an `O(1)` operation instead of `O(n)` for lists.