### PR TITLE
Updates names, check for dimensionless standard names

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -947,8 +947,9 @@ class CFBaseCheck(BaseCheck):
                                                                standard_name)
         # Is this even in the database? also, if there is no standard_name,
         # there's no way to know if it is dimensionless.
-        should_be_dimensionless = (variable.ndim == 0 or variable.dtype.char == 'S' or
-                                   std_name_units_dimensionless or standard_name is None)
+        should_be_dimensionless = (variable.dtype.char == 'S' or
+                                   std_name_units_dimensionless or
+                                   standard_name is None)
 
         # 1) Units must exist
         valid_units = TestCtx(BaseCheck.HIGH, '§3.1 Variable {} contains valid CF units'.format(variable_name))

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -942,7 +942,7 @@ class CFBaseCheck(BaseCheck):
         units = getattr(variable, 'units', None)
         standard_name_full = getattr(variable, 'standard_name', None)
         standard_name, standard_name_modifier = self._split_standard_name(standard_name_full)
-        std_name_units_dimensionless = cfutil.get_dimensionless_standard_names(self._std_names._root,
+        std_name_units_dimensionless = cfutil.is_dimensionless_standard_name(self._std_names._root,
                                                                standard_name)
         # Is this even in the database? also, if there is no standard_name,
         # there's no way to know if it is dimensionless.
@@ -979,7 +979,7 @@ class CFBaseCheck(BaseCheck):
         units = getattr(variable, 'units', None)
         standard_name = getattr(variable, 'standard_name', None)
         standard_name, standard_name_modifier = self._split_standard_name(standard_name)
-        std_name_units_dimensionless = cfutil.get_dimensionless_standard_names(self._std_names._root,
+        std_name_units_dimensionless = cfutil.is_dimensionless_standard_name(self._std_names._root,
                                                                standard_name)
 
         # If the variable is supposed to be dimensionless, it automatically passes
@@ -1015,7 +1015,7 @@ class CFBaseCheck(BaseCheck):
                                                                      standard_name or "unspecified"))
 
         # If the variable is supposed to be dimensionless, it automatically passes
-        std_name_units_dimensionless = cfutil.get_dimensionless_standard_names(self._std_names._root,
+        std_name_units_dimensionless = cfutil.is_dimensionless_standard_name(self._std_names._root,
                                                                standard_name)
 
         standard_name, standard_name_modifier = self._split_standard_name(standard_name)

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -952,7 +952,7 @@ class CFBaseCheck(BaseCheck):
         # 1) Units must exist
         valid_units = TestCtx(BaseCheck.HIGH, '§3.1 Variable {} contains valid CF units'.format(variable_name))
         valid_units.assert_true(should_be_dimensionless or units is not None,
-                                'units attribute is required for {} when'.format(variable_name))
+                                'units attribute is required for {} when variable is not a dimensionless quantity'.format(variable_name))
 
         # Don't bother checking the rest
         if units is None and not should_be_dimensionless:

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -985,11 +985,8 @@ class CFBaseCheck(BaseCheck):
                                                                standard_name)
 
         # If the variable is supposed to be dimensionless, it automatically passes
-        should_be_dimensionless = (
-            variable.ndim == 0 or
-            variable.dtype.char == 'S' or
-            std_name_units_dimensionless
-        )
+        should_be_dimensionless = (variable.dtype.char == 'S' or
+                                   std_name_units_dimensionless)
 
         valid_udunits = TestCtx(BaseCheck.LOW,
                                 "§3.1 Variable {}'s units are contained in UDUnits".format(variable_name))

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -942,23 +942,23 @@ class CFBaseCheck(BaseCheck):
         units = getattr(variable, 'units', None)
         standard_name_full = getattr(variable, 'standard_name', None)
         standard_name, standard_name_modifier = self._split_standard_name(standard_name_full)
-        std_name_unitless = cfutil.get_unitless_standard_names(self._std_names._root,
+        std_name_units_dimensionless = cfutil.get_dimensionless_standard_names(self._std_names._root,
                                                                standard_name)
         # Is this even in the database? also, if there is no standard_name,
-        # there's no way to know if it is unitless.
-        should_be_unitless = (variable.ndim == 0 or variable.dtype.char == 'S' or
-                              std_name_unitless or standard_name is None)
+        # there's no way to know if it is dimensionless.
+        should_be_dimensionless = (variable.ndim == 0 or variable.dtype.char == 'S' or
+                                   std_name_units_dimensionless or standard_name is None)
 
         # 1) Units must exist
         valid_units = TestCtx(BaseCheck.HIGH, '§3.1 Variable {} contains valid CF units'.format(variable_name))
-        valid_units.assert_true(should_be_unitless or units is not None,
-                                'units attribute is required for {}'.format(variable_name))
+        valid_units.assert_true(should_be_dimensionless or units is not None,
+                                'units attribute is required for {} when'.format(variable_name))
 
         # Don't bother checking the rest
-        if units is None and not should_be_unitless:
+        if units is None and not should_be_dimensionless:
             return valid_units.to_result()
         # 2) units attribute must be a string
-        valid_units.assert_true(should_be_unitless or isinstance(units, basestring),
+        valid_units.assert_true(should_be_dimensionless or isinstance(units, basestring),
                                 'units attribute for {} needs to be a string'.format(variable_name))
 
         # 3) units are not deprecated
@@ -979,20 +979,20 @@ class CFBaseCheck(BaseCheck):
         units = getattr(variable, 'units', None)
         standard_name = getattr(variable, 'standard_name', None)
         standard_name, standard_name_modifier = self._split_standard_name(standard_name)
-        std_name_unitless = cfutil.get_unitless_standard_names(self._std_names._root,
+        std_name_units_dimensionless = cfutil.get_dimensionless_standard_names(self._std_names._root,
                                                                standard_name)
 
-        # If the variable is supposed to be unitless, it automatically passes
-        should_be_unitless = (
+        # If the variable is supposed to be dimensionless, it automatically passes
+        should_be_dimensionless = (
             variable.ndim == 0 or
             variable.dtype.char == 'S' or
-            std_name_unitless
+            std_name_units_dimensionless
         )
 
         valid_udunits = TestCtx(BaseCheck.LOW,
                                 "§3.1 Variable {}'s units are contained in UDUnits".format(variable_name))
         are_udunits = (units is not None and util.units_known(units))
-        valid_udunits.assert_true(should_be_unitless or are_udunits,
+        valid_udunits.assert_true(should_be_dimensionless or are_udunits,
                                   'units for {}, "{}" are not recognized by udunits'.format(variable_name, units))
         return valid_udunits.to_result()
 
@@ -1014,8 +1014,8 @@ class CFBaseCheck(BaseCheck):
                                        "the standard_name {}".format(variable_name,
                                                                      standard_name or "unspecified"))
 
-        # If the variable is supposed to be unitless, it automatically passes
-        std_name_unitless = cfutil.get_unitless_standard_names(self._std_names._root,
+        # If the variable is supposed to be dimensionless, it automatically passes
+        std_name_units_dimensionless = cfutil.get_dimensionless_standard_names(self._std_names._root,
                                                                standard_name)
 
         standard_name, standard_name_modifier = self._split_standard_name(standard_name)
@@ -1059,8 +1059,8 @@ class CFBaseCheck(BaseCheck):
                                              'variables defining longitude must use degrees_east '
                                              'or degrees if defining a transformed grid. Currently '
                                              '{}'.format(units))
-        # Standard Name table agrees the unit should be unitless
-        elif std_name_unitless:
+        # Standard Name table agrees the unit should be dimensionless
+        elif std_name_units_dimensionless:
             valid_standard_units.assert_true(True, '')
 
         elif canonical_units is not None:

--- a/compliance_checker/cfutil.py
+++ b/compliance_checker/cfutil.py
@@ -55,9 +55,10 @@ DIMENSIONLESS_VERTICAL_COORDINATES = {
 
 def get_dimensionless_standard_names(xml_tree, standard_name):
     '''
-    Returns True if the units for the associated standard name are unitless.
-    Unitless includes units that have no units and units that are defined as
-    constant units in the CF standard name table i.e. '1', or '1e-3'.
+    Returns True if the units for the associated standard name are
+    dimensionless.  Dimensionless standard names include those that have no
+    units and units that are defined as constant units in the CF standard name
+    table i.e. '1', or '1e-3'.
     '''
     # standard_name must be string, so if it is not, it is *wrong* by default
     if not isinstance(standard_name, basestring):
@@ -69,7 +70,7 @@ def get_dimensionless_standard_names(xml_tree, standard_name):
         # 1 and 1e-3 for unitless dims, but expanding to valid udunits
         # prefixes to be on the safe side
         # taken from CF Table 3.1 of valid UDUnits prefixes
-        dimless_units = r'1(?:e-?(?:1|2|3|6|9|12|15|18|21|24))$'
+        dimless_units = r'1(?:e-?(?:1|2|3|6|9|12|15|18|21|24))?$'
         return canonical_units is None or re.match(dimless_units,
                                                    canonical_units.text)
     # if the standard name is not found, assume we need units for the time being

--- a/compliance_checker/cfutil.py
+++ b/compliance_checker/cfutil.py
@@ -53,7 +53,7 @@ DIMENSIONLESS_VERTICAL_COORDINATES = {
 }
 
 
-def get_dimensionless_standard_names(xml_tree, standard_name):
+def is_dimensionless_standard_name(xml_tree, standard_name):
     '''
     Returns True if the units for the associated standard name are
     dimensionless.  Dimensionless standard names include those that have no

--- a/compliance_checker/cfutil.py
+++ b/compliance_checker/cfutil.py
@@ -53,15 +53,25 @@ DIMENSIONLESS_VERTICAL_COORDINATES = {
 }
 
 
-def get_unitless_standard_names(xml_tree, units):
+def get_dimensionless_standard_names(xml_tree, standard_name):
     '''
-    Returns True if the units are unitless. Unitless includes units that have
-    no units and units that are defined as '1'.
+    Returns True if the units for the associated standard name are unitless.
+    Unitless includes units that have no units and units that are defined as
+    constant units in the CF standard name table i.e. '1', or '1e-3'.
     '''
-    found_standard_name = xml_tree.find(".//entry[@id='{}']".format(units))
+    # standard_name must be string, so if it is not, it is *wrong* by default
+    if not isinstance(standard_name, basestring):
+        return False
+    found_standard_name = xml_tree.find(".//entry[@id='{}']".format(standard_name))
     if found_standard_name is not None:
         canonical_units = found_standard_name.find('canonical_units')
-        return canonical_units is None or canonical_units.text == '1'
+        # so far, standard name XML table includes
+        # 1 and 1e-3 for unitless dims, but expanding to valid udunits
+        # prefixes to be on the safe side
+        # taken from CF Table 3.1 of valid UDUnits prefixes
+        dimless_units = r'1(?:e-?(?:1|2|3|6|9|12|15|18|21|24))$'
+        return canonical_units is None or re.match(dimless_units,
+                                                   canonical_units.text)
     # if the standard name is not found, assume we need units for the time being
     else:
         return False

--- a/compliance_checker/cfutil.py
+++ b/compliance_checker/cfutil.py
@@ -67,7 +67,7 @@ def is_dimensionless_standard_name(xml_tree, standard_name):
     if found_standard_name is not None:
         canonical_units = found_standard_name.find('canonical_units')
         # so far, standard name XML table includes
-        # 1 and 1e-3 for unitless dims, but expanding to valid udunits
+        # 1 and 1e-3 for constant units, but expanding to valid udunits
         # prefixes to be on the safe side
         # taken from CF Table 3.1 of valid UDUnits prefixes
         dimless_units = r'1(?:e-?(?:1|2|3|6|9|12|15|18|21|24))?$'

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -4,6 +4,7 @@
 from compliance_checker.suite import CheckSuite
 from compliance_checker.cf import CFBaseCheck, dimless_vertical_coordinates
 from compliance_checker.cf.util import is_vertical_coordinate, is_time_variable, units_convertible, units_temporal, StandardNameTable, create_cached_data_dir, download_cf_standard_name_table
+from compliance_checker import cfutil
 from netCDF4 import Dataset
 from tempfile import gettempdir
 from compliance_checker.tests.resources import STATIC_FILES
@@ -774,8 +775,6 @@ class TestCF(BaseTestCase):
         self.assertTrue('Attribute formula_terms is not well-formed'
                         in result.msgs)
 
-
-
     def test_is_time_variable(self):
         var1 = MockVariable()
         var1.standard_name = 'time'
@@ -793,6 +792,19 @@ class TestCF(BaseTestCase):
         var4 = MockVariable()
         var4.units = 'seconds since 1900-01-01'
         self.assertTrue(is_time_variable('maybe_time', var4))
+
+    def test_dimensionless_standard_names(self):
+        """Check that dimensionless standard names are properly detected"""
+        std_names_xml_root = self.cf._std_names._root
+        # canonical_units are K, should be False
+        self.assertFalse(cfutil.is_dimensionless_standard_name(std_names_xml_root,
+                                                             'sea_water_temperature'))
+        # canonical_units are 1, should be True
+        self.assertTrue(cfutil.is_dimensionless_standard_name(std_names_xml_root,
+                                                             'sea_water_practical_salinity'))
+        # canonical_units are 1e-3, should be True
+        self.assertTrue(cfutil.is_dimensionless_standard_name(std_names_xml_root,
+                                                             'sea_water_salinity'))
 
     def test_check_time_coordinate(self):
         dataset = self.load_dataset(STATIC_FILES['example-grid'])


### PR DESCRIPTION
Renames a number of functions and variables related to checks for units
when standard_name is determined to be dimensionless.  Also expands the
accepted UDUnits dimensionless units names checked.