### PR TITLE
Allow StandardNameTable to optionally load CF standard name table fro…

### DIFF
--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -265,6 +265,9 @@ class StandardNameTable(object):
         if cached_location:
             with io.open(cached_location, 'r', encoding='utf-8') as fp:
                 resource_text = fp.read()
+        elif os.environ.get('CF_STANDARD_NAME_TABLE') and os.path.exists(os.environ['CF_STANDARD_NAME_TABLE']):
+            with io.open(os.environ['CF_STANDARD_NAME_TABLE'], 'r', encoding='utf-8') as fp:
+                resource_text = fp.read()
         else:
             resource_text = get_data("compliance_checker", "data/cf-standard-name-table.xml")
 


### PR DESCRIPTION
…m a local path defined by an environment variable

This PR is mostly to gauge whether you are interested in supporting alternate means of loading the CF standard name table, in addition to the current mechanisms.

The use case for this in particular is that we install compliance_checker via configuration management, and would like to de-couple the management of the XML from the compliance-checker package, so that package updates don't require re-downloading the file when we have already determined what we consider to be our internally supported version.

It would be nice to able to manage the XML outside the package's data directory as part of the deployed environment, hence the environment variable idea. 

