### PR TITLE
remove cython

### DIFF
--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -10,4 +10,3 @@ netCDF4>=1.4.0
 regex==2017.07.28
 pendulum>=1.2.4
 tabulate==0.8.2
-cython

--- a/conda-requirements_pre3_2.txt
+++ b/conda-requirements_pre3_2.txt
@@ -10,7 +10,6 @@ netCDF4>=1.4.0
 regex==2017.07.28
 pendulum>=1.2.4
 tabulate==0.8.2
-cython
 # functools.lru_cache first appears in Python 3.2, use this for other
 # versions
 functools32==3.2.3-2

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -16,7 +16,6 @@ requirements:
     - pip
   run:
     - python
-    - cython
     - setuptools
     - cf_units >=2
     - isodate >=0.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ netCDF4>=1.4.0
 regex==2017.07.28
 pendulum>=1.2.4
 tabulate==0.8.2
-cython
 # functools.lru_cache first appears in Python 3.2, use this for other
 # versions
 functools32==3.2.3-2; python_version < '3.2'


### PR DESCRIPTION
I don't know why `cython` was added but it is not used to build any code in compliance-checker and it is rarely a run time dependency. If we ever use `cython` in the future we must make it a `build` dependency only and never `run`.