### PR TITLE
Show help when no operations are requested on the command line, updates #607

### DIFF
--- a/cchecker.py
+++ b/cchecker.py
@@ -94,7 +94,7 @@ def main():
 
     if len(args.dataset_location) == 0:
         parser.print_help()
-        return 0
+        return 1
 
     # Check the number of output files
     if not args.output:

--- a/cchecker.py
+++ b/cchecker.py
@@ -92,6 +92,10 @@ def main():
     if args.download_standard_names:
         download_cf_standard_name_table(args.download_standard_names)
 
+    if len(args.dataset_location) == 0:
+        parser.print_help()
+        return 0
+
     # Check the number of output files
     if not args.output:
         args.output = '-'


### PR DESCRIPTION
This does not technically "fix" #607, as there are still ways to call that method and get the UnboundLocalError esp when using CC programatically, but this makes it behave like a command line tool is expected to.