### PR TITLE
Allows skipping specific levels of individual checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,15 @@ optional arguments:
                         Normal, or Lenient. Defaults to Normal.
   --verbose, -v         Increase output. May be specified up to three times.
   --skip-checks SKIP_CHECKS, -s SKIP_CHECKS
-                        Specifies tests to skip
+                        Specifies tests to skip. Can take the form of either
+                        `<check_name>` or `<check_name>:<skip_level>`.  The
+                        first form skips any checks matching the name.  In the
+                        second form <skip_level> may be specified as "A", "M",
+                        or "L".  "A" skips all checks and is equivalent to
+                        calling the first form. "M" will only show high
+                        priority output from the given check and will skip
+                        medium and low.  "L" will show both high and medium
+                        priority issues, while skipping low priority issues.
   -f {text,html,json,json_new}, --format {text,html,json,json_new}
                         Output format. The difference between the 'json' and
                         the 'json_new' formats is that the 'json' format has

--- a/cchecker.py
+++ b/cchecker.py
@@ -6,6 +6,7 @@ import sys
 from compliance_checker.runner import ComplianceChecker, CheckSuite
 from compliance_checker.cf.util import download_cf_standard_name_table
 from compliance_checker import __version__
+from textwrap import dedent
 
 
 def main():
@@ -33,7 +34,20 @@ def main():
                         default=0)
 
     parser.add_argument('--skip-checks', '-s',
-                        help="Specifies tests to skip",
+                        help=dedent("""
+                                    Specifies tests to skip. Can take the form
+                                    of either `<check_name>` or
+                                    `<check_name>:<skip_level>`.  The first
+                                    form skips any checks matching the name.
+                                    In the second form <skip_level> may be
+                                    specified as "A", "M", or "L".  "A" skips
+                                    all checks and is equivalent to calling
+                                    the first form. "M" will only show high
+                                    priority output from the given check and
+                                    will skip medium and low.  "L" will show
+                                    both high and medium priority issues, while
+                                    skipping low priority issues.
+                                    """),
                         action='append')
 
     parser.add_argument('-f', '--format', default=[], action='append',

--- a/compliance_checker/runner.py
+++ b/compliance_checker/runner.py
@@ -30,6 +30,7 @@ class ComplianceChecker(object):
     Ties together the entire compliance checker framework, is used from
     the command line or can be used via import.
     """
+    # Consider using __init__ instead of so many classmethods
     @classmethod
     def run_checker(cls, ds_loc, checker_names, verbose, criteria,
                     skip_checks=None, output_filename='-',
@@ -64,8 +65,7 @@ class ComplianceChecker(object):
         for loc in locs:
             ds = cs.load_dataset(loc)
 
-            score_groups = cs.run(ds, [] if skip_checks is None else skip_checks,
-                                *checker_names)
+            score_groups = cs.run(ds, skip_checks, *checker_names)
             # TODO: consider wrapping in a proper context manager instead
             if hasattr(ds, 'close'):
                 ds.close()

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -17,7 +17,10 @@ from compliance_checker.base import fix_return_value, Result, GenericFile
 from owslib.sos import SensorObservationService
 from owslib.swe.sensor.sml import SensorML
 from compliance_checker.protocols import opendap, netcdf, cdl
+from compliance_checker.base import BaseCheck
 from compliance_checker import MemoizedDataset
+from collections import defaultdict
+import warnings
 try:
     from urlparse import urlparse
 except ImportError:
@@ -122,16 +125,36 @@ class CheckSuite(object):
         """
         meths = inspect.getmembers(checkclass, inspect.ismethod)
         # return all check methods not among the skipped checks
-        return [x[1] for x in meths if x[0].startswith("check_") and
-                x[0] not in skip_checks]
+        returned_checks = []
+        for fn_name, fn_obj in meths:
+            if (fn_name.startswith("check_") and
+                skip_checks[fn_name] != BaseCheck.HIGH):
+                returned_checks.append((fn_obj, skip_checks[fn_name]))
 
-    def _run_check(self, check_method, ds):
+        return returned_checks
+
+    def _run_check(self, check_method, ds, max_level):
+        """
+        Runs a check and appends a result to the
+        """
         val = check_method(ds)
 
         if isinstance(val, list):
-            return [fix_return_value(v, check_method.__func__.__name__, check_method, check_method.__self__) for v in val]
+            check_val = []
+            for v in val:
+                res = fix_return_value(v, check_method.__func__.__name__,
+                                       check_method, check_method.__self__)
+                if max_level is None or res.weight > max_level:
+                    check_val.append(res)
 
-        return [fix_return_value(val, check_method.__func__.__name__, check_method, check_method.__self__)]
+            return check_val
+        else:
+            check_val = fix_return_value(val, check_method.__func__.__name__,
+                                         check_method, check_method.__self__)
+            if max_level is None or check_val.weight > max_level:
+                return [check_val]
+            else:
+                return []
 
     def _get_check_versioned_name(self, check_name):
         """
@@ -184,6 +207,39 @@ class CheckSuite(object):
 
         return valid
 
+
+    @classmethod
+    def _process_skip_checks(cls, skip_checks):
+        """
+        Processes an iterable of skip_checks with strings and returns a dict
+        with <check_name>: <max_skip_level> pairs
+        """
+
+        check_dict = defaultdict(lambda: None)
+        # A is for "all", "M" is for medium, "L" is for low
+        check_lookup = {'A': BaseCheck.HIGH,
+                        'M': BaseCheck.MEDIUM,
+                        'L': BaseCheck.LOW}
+
+        for skip_check_spec in skip_checks:
+            split_check_spec = skip_check_spec.split(':')
+            check_name = split_check_spec[0]
+            if len(split_check_spec) < 2:
+               check_max_level = BaseCheck.HIGH
+            else:
+                try:
+                    check_max_level = check_lookup[split_check_spec[1]]
+                except KeyError:
+                    warnings.warn("Skip specifier '{}' on check '{}' not found,"
+                                  " defaulting to skip entire check".format(split_check_spec[1], check_name))
+                    check_max_level = BaseCheck.HIGH
+
+            check_dict[check_name] = check_max_level
+
+        return check_dict
+
+
+
     def run(self, ds, skip_checks, *checker_names):
         """
         Runs this CheckSuite on the dataset with all the passed Checker instances.
@@ -194,6 +250,11 @@ class CheckSuite(object):
         ret_val = {}
         checkers = self._get_valid_checkers(ds, checker_names)
 
+        if skip_checks is not None:
+            skip_check_dict = CheckSuite._process_skip_checks(skip_checks)
+        else:
+            skip_check_dict = defaultdict(lambda: None)
+
         if len(checkers) == 0:
             print("No valid checkers found for tests '{}'".format(",".join(checker_names)))
 
@@ -202,13 +263,13 @@ class CheckSuite(object):
             checker = checker_class()
             checker.setup(ds)
 
-            checks = self._get_checks(checker, skip_checks)
+            checks = self._get_checks(checker, skip_check_dict)
             vals = []
             errs = {}   # check method name -> (exc, traceback)
 
-            for c in checks:
+            for c, max_level in checks:
                 try:
-                    vals.extend(self._run_check(c, ds))
+                    vals.extend(self._run_check(c, ds, max_level))
                 except Exception as e:
                     errs[c.__func__.__name__] = (e, sys.exc_info()[2])
 

--- a/compliance_checker/tests/test_suite.py
+++ b/compliance_checker/tests/test_suite.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from pkg_resources import resource_filename
 from compliance_checker.suite import CheckSuite
 from compliance_checker.base import Result, BaseCheck, GenericFile
@@ -86,11 +87,11 @@ class TestSuite(unittest.TestCase):
         self.assertTrue(len(expected_excluded_names & name_set) == 0)
 
         # should skip references
-        ref_msg = 'references global attribute should be a non-empty string'
+        ref_msg = u'references global attribute should be a non-empty string'
         self.assertTrue(ref_msg not in msg_set)
         # check_standard_name is high priority, but we requested only low,
         # so the standard_name check should still exist
-        standard_name_hdr = '§3.3 Variable salinity has valid standard_name attribute'
+        standard_name_hdr = u'§3.3 Variable salinity has valid standard_name attribute'
         self.assertTrue(standard_name_hdr in name_set)
 
     def test_group_func(self):

--- a/compliance_checker/tests/test_suite.py
+++ b/compliance_checker/tests/test_suite.py
@@ -77,11 +77,11 @@ class TestSuite(unittest.TestCase):
         # flattened set of messages
         msg_set = {msg for sg in score_groups['cf'][0] for msg in sg.msgs}
 
-        expected_excluded_names = {'§3.5 flag_meanings for lat',
-                                   '§3.5 flag_meanings for lon',
-                                   '§3.5 lat is a valid flags variable',
-                                   '§3.5 lat is a valid flags variable',
-                                   '§3.5 lon is a valid flags variable'}
+        expected_excluded_names = {u'§3.5 flag_meanings for lat',
+                                   u'§3.5 flag_meanings for lon',
+                                   u'§3.5 lat is a valid flags variable',
+                                   u'§3.5 lat is a valid flags variable',
+                                   u'§3.5 lon is a valid flags variable'}
 
         self.assertTrue(len(expected_excluded_names & name_set) == 0)
 


### PR DESCRIPTION
Allows skipping of specific priority levels from within checks by using
a modified form of `<skip_check>:<max_level>`.  Max level can be one of
"A", "M", or "L", which correspond to skipping all output (same as
default invocation with `<skip_check>`), skipping medium and low priority
items within the check, and skipping only low priority checks,
respectively.  Implements #589.