### PR TITLE
Remove variable names from CF reasoning

### DIFF
--- a/compliance_checker/runner.py
+++ b/compliance_checker/runner.py
@@ -62,7 +62,7 @@ class ComplianceChecker(object):
         if isinstance(output_format, six.string_types):
             output_format = [output_format]
 
-        for loc in locs:
+        for loc in locs: # loop through each dataset and run specified checks
             ds = cs.load_dataset(loc)
 
             score_groups = cs.run(ds, skip_checks, *checker_names)
@@ -137,6 +137,7 @@ class ComplianceChecker(object):
                 score_list, points, out_of = cs.standard_output(ds, limit,
                                                                 checker,
                                                                 groups)
+                # send list of grouped result objects to stdout & reasoning_routine
                 cs.standard_output_generation(groups, limit, points, out_of,
                                               check=checker)
         return groups

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -133,7 +133,11 @@ class CheckSuite(object):
 
     def _run_check(self, check_method, ds, max_level):
         """
-        Runs a check and appends a result to the
+        Runs a check and appends a result to the values list.
+        @param bound method check_method: a given check method
+        @param netCDF4 dataset ds
+        @param int max_level: check level
+        @return list: list of Result objects
         """
         val = check_method(ds)
 
@@ -489,10 +493,13 @@ class CheckSuite(object):
 
         sort_fn = lambda x: x.weight
         groups_sorted = sorted(groups, key=sort_fn, reverse=True)
+
+        # create dict of the groups -> {level: [reasons]}
         result = {key: [v for v in valuesiter if v.value[0] != v.value[1]]
                     for key, valuesiter in itertools.groupby(groups_sorted,
                                                              key=sort_fn)}
         priorities = self.checkers[check]._cc_display_headers
+
         def process_table(res, check):
             issue = res.name
             if not res.children:


### PR DESCRIPTION
Referencing #617 

To condense the messages for the CF checks, removed the variable names from
the reason names. Messages with like reason names are printed as groups.

Additionally, added a few lines of doc strings and a couple comments to
help navigate around the code.