### PR TITLE
support url fillmismatch workaround

### DIFF
--- a/compliance_checker/protocols/opendap.py
+++ b/compliance_checker/protocols/opendap.py
@@ -14,7 +14,10 @@ def is_opendap(url):
     :param str url: URL for a remote OPeNDAP endpoint
     '''
     # If the server replies to a Data Attribute Structure request
-    das_url = url + '.das'
+    if url.endswith('#fillmismatch'):
+        das_url = url.replace('#fillmismatch', '.das')
+    else:
+        das_url = url + '.das'
     response = requests.get(das_url, allow_redirects=True)
     if 'xdods-server' in response.headers:
         return True


### PR DESCRIPTION
Latest `netcdf-c` broke a lot of our datasets due to https://github.com/Unidata/netcdf-c/issues/1299. For now we have a workaround by adding `#fillmismatch` to the end of the URL endpoint, but that breaks `compliance-checker`'s `is_opendap`.

This PR adds a support for the URL with the workaround.