### PR TITLE
Fix issue with report icon dropdown click not working

### DIFF
--- a/compliance_checker/data/templates/ccheck_wrapper.html.j2
+++ b/compliance_checker/data/templates/ccheck_wrapper.html.j2
@@ -199,6 +199,7 @@ thead .ccorrection {
     <script type="text/javascript">
 $(document).ready(function() {
     $('.high-priority-table').collapse({toggle: false});
+
     $('.table-collapse').click(function(e) {
       e.preventDefault();
       // Find table to toggle within this check
@@ -206,6 +207,23 @@ $(document).ready(function() {
       $(checkWrapper).find('.' + $(e.target).data('target')).collapse('toggle');
 
       var glyph = $(e.target).find('.glyphicon');
+      if(glyph.hasClass('glyphicon-collapse-up')) {
+        glyph.removeClass('glyphicon-collapse-up');
+        glyph.addClass('glyphicon-collapse-down');
+      } else {
+        glyph.removeClass('glyphicon-collapse-down');
+        glyph.addClass('glyphicon-collapse-up');
+      }
+    });
+
+
+    $('.table-collapse i.glyphicon').click(function(e) {
+      e.preventDefault();
+      // Find table to toggle within this check
+      var checkWrapper = $(e.target).closest(".check_wrapper");
+      $(checkWrapper).find('.' + $(e.target.parentElement).data('target')).collapse('toggle');
+
+      var glyph = $(e.target.parentElement).find('.glyphicon');
       if(glyph.hasClass('glyphicon-collapse-up')) {
         glyph.removeClass('glyphicon-collapse-up');
         glyph.addClass('glyphicon-collapse-down');


### PR DESCRIPTION
Clicking directly on icon was not working, only click on text would hide/show.
![image](https://user-images.githubusercontent.com/9978238/53502202-99f6fd80-3a7b-11e9-952f-a658936ceaa0.png)

@Bobfrat @daltonkell 