### PR TITLE
Quick Improvements 2019-04-11

### DIFF
--- a/compliance_checker/acdd.py
+++ b/compliance_checker/acdd.py
@@ -223,11 +223,23 @@ class ACDDBaseCheck(BaseCheck):
 
         :param netCDF4.Dataset ds: An open netCDF dataset
         '''
-        if not (hasattr(ds, 'geospatial_lat_min') and hasattr(ds, 'geospatial_lat_max')):
-            return
 
-        lat_min = float(ds.geospatial_lat_min)
-        lat_max = float(ds.geospatial_lat_max)
+        if not (hasattr(ds, 'geospatial_lat_min') or hasattr(ds, 'geospatial_lat_max')):
+            return Result(BaseCheck.MEDIUM,
+                          False,
+                          'geospatial_lat_extents_match',
+                          ['geospatial_lat_min/max attribute not found, CF-1.6 spec chapter 4.1'])
+
+        try: # type cast
+            lat_min = float(ds.geospatial_lat_min)
+            lat_max = float(ds.geospatial_lat_max)
+        except ValueError:
+            return Result(BaseCheck.MEDIUM,
+                          False,
+                          'geospatial_lat_extents_match',
+                          ['Could not convert one of geospatial_lat_min ({}) or max ({}) to float see CF-1.6 spec chapter 4.1'
+                          ''.format(ds.geospatial_lat_min, ds.geospatial_lat_max)])
+            
 
         # identify lat var(s) as per CF 4.1
         lat_vars = {}       # var -> number of criteria passed
@@ -289,11 +301,22 @@ class ACDDBaseCheck(BaseCheck):
 
         :param netCDF4.Dataset ds: An open netCDF dataset
         '''
-        if not (hasattr(ds, 'geospatial_lon_min') and hasattr(ds, 'geospatial_lon_max')):
-            return
 
-        lon_min = float(ds.geospatial_lon_min)
-        lon_max = float(ds.geospatial_lon_max)
+        if not (hasattr(ds, 'geospatial_lon_min') and hasattr(ds, 'geospatial_lon_max')):
+            return Result(BaseCheck.MEDIUM,
+                          False,
+                          'geospatial_lon_extents_match',
+                          ['geospatial_lon_min/max attribute not found, CF-1.6 spec chapter 4.1'])
+
+        try: # type cast
+            lon_min = float(ds.geospatial_lon_min)
+            lon_max = float(ds.geospatial_lon_max)
+        except ValueError:
+            return Result(BaseCheck.MEDIUM,
+                          False,
+                          'geospatial_lon_extents_match',
+                          ['Could not convert one of geospatial_lon_min ({}) or max ({}) to float see CF-1.6 spec chapter 4.1'
+                          ''.format(ds.geospatial_lon_min, ds.geospatial_lon_max)])
 
         # identify lon var(s) as per CF 4.2
         lon_vars = {}       # var -> number of criteria passed

--- a/compliance_checker/acdd.py
+++ b/compliance_checker/acdd.py
@@ -226,8 +226,8 @@ class ACDDBaseCheck(BaseCheck):
         if not (hasattr(ds, 'geospatial_lat_min') and hasattr(ds, 'geospatial_lat_max')):
             return
 
-        lat_min = ds.geospatial_lat_min
-        lat_max = ds.geospatial_lat_max
+        lat_min = float(ds.geospatial_lat_min)
+        lat_max = float(ds.geospatial_lat_max)
 
         # identify lat var(s) as per CF 4.1
         lat_vars = {}       # var -> number of criteria passed
@@ -292,8 +292,8 @@ class ACDDBaseCheck(BaseCheck):
         if not (hasattr(ds, 'geospatial_lon_min') and hasattr(ds, 'geospatial_lon_max')):
             return
 
-        lon_min = ds.geospatial_lon_min
-        lon_max = ds.geospatial_lon_max
+        lon_min = float(ds.geospatial_lon_min)
+        lon_max = float(ds.geospatial_lon_max)
 
         # identify lon var(s) as per CF 4.2
         lon_vars = {}       # var -> number of criteria passed
@@ -377,8 +377,8 @@ class ACDDBaseCheck(BaseCheck):
         :param netCDF4.Dataset ds: An open netCDF dataset
         :param str z_variable: Name of the variable representing the Z-Axis
         '''
-        vert_min = ds.geospatial_vertical_min
-        vert_max = ds.geospatial_vertical_max
+        vert_min = float(ds.geospatial_vertical_min)
+        vert_max = float(ds.geospatial_vertical_max)
         msgs = []
         total = 2
 
@@ -698,7 +698,7 @@ class ACDD1_3Check(ACDDNCCheck):
                             'coverage_content_type', None)
             check = ctype is not None
             if not check:
-                msgs.append("coverage_content")
+                msgs.append("coverage_content_type")
                 results.append(Result(BaseCheck.HIGH, check,
                                       self._var_header.format(variable), msgs))
                 continue

--- a/compliance_checker/tests/helpers.py
+++ b/compliance_checker/tests/helpers.py
@@ -27,6 +27,12 @@ class MockTimeSeries(MockNetCDF):
         for v in ('time', 'lon', 'lat', 'depth'):
             self.createVariable(v, 'd', ('time',))
 
+        # give some applicable units
+        self.variables["time"].units  = "seconds since 2019-04-11T00:00:00"
+        self.variables["lat"].units   = "degree_north"
+        self.variables["lon"].units   = "degree_east"
+        self.variables["depth"].units = "meters"
+
 
 class MockVariable(object):
     '''


### PR DESCRIPTION
Addresses a few quick issues related to comparing data values to metadata, message improvements.

acdd.py:
  - check_lat_extents(), check_lon_extents(), and _check_total_z_extents() -- all tried to compare
    data values to metadata values, which may have been passed as strings. numpy copmarision would
    subsequently fail; fixed by casting the potential string values as floats (Issue #639)
  - check_coverage_content_type() was outputting the string "coverage_content" instead of
    "coverage_content_type"; inserted the correct string (Issue #637)

cf.py:
  - _check_formula_terms() was outputting a message about missing variables, but did not include
    the variables it was referring to. Fixed by adding a format field. (Issue #636)
  - check_grid_coordinates() message was a little ambiguous -- added some context, as well
    as a message for variables with missing coordinate variables (Issue #638)