### PR TITLE
Handle bad CF standard name table versions

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -175,7 +175,12 @@ class CFBaseCheck(BaseCheck):
                 if len(version) > 1:
                     return False
                 else:
-                    version = version[0]
+                    try:
+                        version = version[0]
+                    except IndexError:
+                        warn("Cannot extract CF standard name version number "
+                             "from standard_name_vocabulary string")
+                        return False
             else:
                 # Can't parse the attribute, use the packaged version
                 return False

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -468,6 +468,12 @@ class TestCF(BaseTestCase):
         nc_obj.standard_name_table = np.array([], np.float64)
         self.assertFalse(self.cf._find_cf_standard_name_table(nc_obj))
 
+        nc_obj.standard_name_vocabulary = "CF Standard Name Table vNN???"
+        with pytest.warns(UserWarning,
+                          match="Cannot extract CF standard name version "
+                                "number from standard_name_vocabulary string"):
+            self.assertFalse(self.cf._find_cf_standard_name_table(nc_obj))
+
     def test_check_flags(self):
         """Test that the check for flags works as expected."""
 


### PR DESCRIPTION
Handles bad and unparseable CF standard name table versions by raising a
warning and returning `False` inside `_find_cf_standard_name_table`