### PR TITLE
Allows checkers using .name attr to be listed

### DIFF
--- a/cchecker.py
+++ b/cchecker.py
@@ -95,13 +95,7 @@ def main():
 
     if args.list_tests:
         print("IOOS compliance checker available checker suites:")
-        for checker in sorted(check_suite.checkers.keys()):
-            version = getattr(check_suite.checkers[checker],
-                              '_cc_checker_version', "???")
-            if args.verbose:
-                print(" - {} (v{})".format(checker, version))
-            elif ':' in checker and not checker.endswith(':latest'):  # Skip the "latest" output
-                print(" - {}".format(checker))
+        check_suite._print_suites(args.verbose)
         return 0
 
     if args.download_standard_names:

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -59,7 +59,7 @@ class CheckSuite(object):
 
         return cls.suite_generators
 
-    def _print_suites(self, verbose=False):
+    def _print_suites(self, verbose=0):
         """
         Prints out available check suites.  If the verbose argument is True,
         includes the internal module version number of the check and also displays


### PR DESCRIPTION
Allows checkers using the `.name` attribute instead of the `._cc_spec` and
`cc_spec_version` to be listed in the checker output.  Checkers using
the former will raise a `DeprecationWarning` indicating the checker is
not preferred.  Also refactors some of the check suite logic for
printing listings and adds unit test for aforementioned behavior.
Addresses #610.