### PR TITLE
Add better error message for the geospatial bounds check

### DIFF
--- a/compliance_checker/acdd.py
+++ b/compliance_checker/acdd.py
@@ -388,8 +388,11 @@ class ACDDBaseCheck(BaseCheck):
             from_wkt(ds.geospatial_bounds)
         except AttributeError:
             return ratable_result(False,
-                                  "Global Attributes", # grouped with Globals
-                                  ['Could not parse WKT, possible bad value for WKT'])
+                                  "Global Attributes",  # grouped with Globals
+                                  [('Could not parse WKT from geospatial_bounds,'
+                                    ' possible bad value: \"{}\"'.format(ds.geospatial_bounds))],
+                                  variable_name='geospatial_bounds'
+                                  )
         # parsed OK
         else:
             return ratable_result(True, "Global Attributes", tuple())

--- a/compliance_checker/base.py
+++ b/compliance_checker/base.py
@@ -374,9 +374,9 @@ def fix_return_value(v, method_name, method=None, checker=None):
     return v
 
 
-def ratable_result(value, name, msgs):
+def ratable_result(value, name, msgs, variable_name=None):
     """Returns a partial function with a Result that has not been weighted."""
-    return lambda w: Result(w, value, name, msgs)
+    return lambda w: Result(w, value, name, msgs, variable_name=variable_name)
 
 
 def score_group(group_name=None):

--- a/compliance_checker/tests/test_acdd.py
+++ b/compliance_checker/tests/test_acdd.py
@@ -408,6 +408,24 @@ class TestACDD1_3(BaseTestCase):
         result = self.acdd.check_vertical_extents(self.ds)
         self.assert_result_is_good(result)
 
+    def test_geospatial_bounds(self):
+        '''
+        Test geospatial bounds are checked and provide a good error message
+        '''
+        # Create an empty dataset that writes to /dev/null This acts as a
+        # temporary netCDF file in-memory that never gets written to disk.
+        empty_ds = Dataset(os.devnull, 'w', diskless=True)
+        self.addCleanup(empty_ds.close)
+
+        # Mispelled WKT. Error message should include the attribute checked
+        # and the value that was provided for easy troubleshooting
+        empty_ds.geospatial_bounds = "POIT (-123.458000 38.048000)"
+        results = self.acdd.check_recommended(empty_ds)
+        for result in results:
+            if result.variable_name == 'geospatial_bounds':
+                assert ('Could not parse WKT from geospatial_bounds,'
+                        ' possible bad value: "{}"'.format(empty_ds.geospatial_bounds) in result.msgs)
+
     def test_time_extents(self):
         '''
         Test that the time extents are being checked


### PR DESCRIPTION
@benjwadams this addresses https://github.com/ioos/compliance-checker/issues/654
Previously the error message did not tell the user which attribute was checked or what the incorrect value was, making it difficult to fix the issue. This PR adds the attribute name and the erroneous value in the error message.