### PR TITLE
Draft --describe-checks feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ parse it's contents.
 
 ```
 usage: cchecker.py [-h] [--test TEST] [--criteria [{lenient,normal,strict}]]
-                   [--verbose] [--skip-checks SKIP_CHECKS]
+                   [--verbose] [--describe-checks] [--skip-checks SKIP_CHECKS]
                    [-f {text,html,json,json_new}] [-o OUTPUT] [-V] [-l]
-                   [-d DOWNLOAD_STANDARD_NAMES]
+                   [-d [DOWNLOAD_STANDARD_NAMES]]
                    [dataset_location [dataset_location ...]]
 
 positional arguments:
@@ -139,20 +139,25 @@ optional arguments:
                         Define the criteria for the checks. Either Strict,
                         Normal, or Lenient. Defaults to Normal.
   --verbose, -v         Increase output. May be specified up to three times.
+  --describe-checks, -D
+                        Describes checks for checkers specified using `-t`. If
+                        `-t` is not specified, lists checks from all available
+                        checkers.
   --skip-checks SKIP_CHECKS, -s SKIP_CHECKS
                         Specifies tests to skip. Can take the form of either
-                        `<check_name>` or `<check_name>:<skip_level>`.  The
-                        first form skips any checks matching the name.  In the
+                        `<check_name>` or `<check_name>:<skip_level>`. The
+                        first form skips any checks matching the name. In the
                         second form <skip_level> may be specified as "A", "M",
-                        or "L".  "A" skips all checks and is equivalent to
+                        or "L". "A" skips all checks and is equivalent to
                         calling the first form. "M" will only show high
                         priority output from the given check and will skip
-                        medium and low.  "L" will show both high and medium
+                        medium and low. "L" will show both high and medium
                         priority issues, while skipping low priority issues.
   -f {text,html,json,json_new}, --format {text,html,json,json_new}
-                        Output format. The difference between the 'json' and
-                        the 'json_new' formats is that the 'json' format has
-                        the check as the top level key, whereas the 'json_new'
+                        Output format(s). Options are 'text', 'html', 'json',
+                        'json_new'. The difference between the 'json' and the
+                        'json_new' formats is that the 'json' format has the
+                        check as the top level key, whereas the 'json_new'
                         format has the dataset name(s) as the main key in the
                         output follow by any checks as subkeys. Also, 'json'
                         format can be only be run against one input file,
@@ -169,7 +174,7 @@ optional arguments:
   -V, --version         Display the IOOS Compliance Checker version
                         information.
   -l, --list-tests      List the available tests
-  -d DOWNLOAD_STANDARD_NAMES, --download-standard-names DOWNLOAD_STANDARD_NAMES
+  -d [DOWNLOAD_STANDARD_NAMES], --download-standard-names [DOWNLOAD_STANDARD_NAMES]
                         Specify a version of the cf standard name table to
                         download as packaged version
 ```

--- a/cchecker.py
+++ b/cchecker.py
@@ -110,8 +110,8 @@ def main():
                 check_suite._print_checker(check_suite.checkers[key])
         else:
             if args.describe_checks not in check_suite.checkers:
-                print("Cannot find checker '{}' to describe tests for"
-                      .format(args.describe_checks), sys.stderr)
+                print("Cannot find checker '{}' with which to describe checks"
+                      .format(args.describe_checks), file=sys.stderr)
                 sys.exit(1)
             else:
                 check = args.describe_checks

--- a/cchecker.py
+++ b/cchecker.py
@@ -9,6 +9,15 @@ from compliance_checker import __version__
 import sys
 from textwrap import dedent
 
+def _print_checker_name_header(checker_str):
+    """
+    Helper function to prints a checker name surrounded by a border of "="
+    :param checker_suite: A check suite string name
+    :type checker: str
+    """
+    print("{0}\n {1} \n{0}".format("=" * (len(checker_str) + 2), checker_str))
+
+
 def main():
     # Load all available checker classes
     check_suite = CheckSuite()
@@ -105,8 +114,7 @@ def main():
                 # skip "latest" meta-versions
                 if ':' not in key or key.endswith(':latest'):
                     continue
-                # print checker name and contents
-                print("{}\n============".format(key))
+                _print_checker_name_header(key)
                 check_suite._print_checker(check_suite.checkers[key])
         else:
             if args.describe_checks not in check_suite.checkers:
@@ -115,7 +123,7 @@ def main():
                 sys.exit(1)
             else:
                 check = args.describe_checks
-                print("{}\n============".format(check))
+                _print_checker_name_header(check)
                 check_suite._print_checker(check_suite.checkers[check])
         sys.exit(0)
 

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -82,10 +82,9 @@ class CheckSuite(object):
         :type checker_obj: subclass of compliance_checker.base.BaseChecker
         """
 
-        check_functions = [t[1] for t in inspect.getmembers(checker_obj,
-                                                            inspect.isfunction)
-                           if t[0].startswith('check_')]
-        for c in check_functions:
+        check_functions = self._get_checks(checker_obj,
+                                           defaultdict(lambda: None))
+        for c, _ in check_functions:
             print("- {}".format(c.__name__))
             if c.__doc__ is not None:
                 print("\n{}\n".format(extract_docstring_summary(c.__doc__)))

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -46,9 +46,12 @@ def extract_docstring_summary(docstring):
     :type docstring: str
     :returns: str
     """
-
-    return textwrap.dedent(re.split(r'\n\s*:\w', docstring,
-                                    flags=re.MULTILINE)[0])
+    # return a dedented, then indented two spaces docstring with leading and
+    # trailing whitespace removed.
+    return re.sub(r'^(?=.)', '  ',
+                  textwrap.dedent(re.split(r'\n\s*:\w', docstring,
+                                           flags=re.MULTILINE)[0]).strip(),
+                  flags=re.MULTILINE)
 
 class CheckSuite(object):
 
@@ -83,9 +86,9 @@ class CheckSuite(object):
                                                             inspect.isfunction)
                            if t[0].startswith('check_')]
         for c in check_functions:
-            print(c.__name__)
+            print("- {}".format(c.__name__))
             if c.__doc__ is not None:
-                print(extract_docstring_summary(c.__doc__))
+                print("\n{}\n".format(extract_docstring_summary(c.__doc__)))
 
     @classmethod
     def add_plugin_args(cls, parser):
@@ -149,8 +152,8 @@ class CheckSuite(object):
         Helper method to retreive check methods from a Checker class.  Excludes
         any checks in `skip_checks`.
 
-        The name of the methods in the Checker class should start with "check_" for this
-        method to find them.
+        The name of the methods in the Checker class should start with "check_"
+        for this method to find them.
         """
         meths = inspect.getmembers(checkclass, inspect.ismethod)
         # return all check methods not among the skipped checks

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -154,7 +154,7 @@ class CheckSuite(object):
         The name of the methods in the Checker class should start with "check_"
         for this method to find them.
         """
-        meths = inspect.getmembers(checkclass, inspect.ismethod)
+        meths = inspect.getmembers(checkclass, inspect.isroutine)
         # return all check methods not among the skipped checks
         returned_checks = []
         for fn_name, fn_obj in meths:

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -72,6 +72,13 @@ class CheckSuite(object):
         return cls.suite_generators
 
     def _print_checker(self, checker_obj):
+        """
+        Prints each available check and a description with an abridged
+        docstring for a given checker object
+        :param checker_obj: Checker object on which to operate
+        :type checker_obj: subclass of compliance_checker.base.BaseChecker
+        """
+
         check_functions = [t[1] for t in inspect.getmembers(checker_obj,
                                                             inspect.isfunction)
                            if t[0].startswith('check_')]

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -31,6 +31,7 @@ import codecs
 import re
 import textwrap
 from pkg_resources import working_set
+import six
 
 
 # Ensure output is encoded as Unicode when checker output is redirected or piped
@@ -87,7 +88,14 @@ class CheckSuite(object):
         for c, _ in check_functions:
             print("- {}".format(c.__name__))
             if c.__doc__ is not None:
-                print("\n{}\n".format(extract_docstring_summary(c.__doc__)))
+                # necessary for unicode characters in docstrings under Python
+                # 2, aside from converting everything over to u'' strings
+                try:
+                    u_doc = six.u(c.__doc__)
+                except TypeError:
+                    u_doc = c.__doc__
+
+                print("\n{}\n".format(extract_docstring_summary(u_doc)))
 
     @classmethod
     def add_plugin_args(cls, parser):


### PR DESCRIPTION
Draft PR for `-D`/`--describe-checks` feature.  User can specify a
particular checker for which to list all defined checks, or '*' to list
all defined checks for all defined checkers.  Prints abridged docstrings
from each `check_*` method in checker classes.  Useful in combination
with `-l` output, or to describe the behavior of certain checks should a
user wish to disable some with `-s`/`--skip-checks`.  PR is still draft
quality and will likely need improvements on formatting and display of
results, but for the time being, I just want to solicit feedback on the general functionality.