### PR TITLE
Describe checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ parse it's contents.
 
 ```
 usage: cchecker.py [-h] [--test TEST] [--criteria [{lenient,normal,strict}]]
-                   [--verbose] [--skip-checks SKIP_CHECKS]
+                   [--verbose] [--describe-checks] [--skip-checks SKIP_CHECKS]
                    [-f {text,html,json,json_new}] [-o OUTPUT] [-V] [-l]
-                   [-d DOWNLOAD_STANDARD_NAMES]
+                   [-d [DOWNLOAD_STANDARD_NAMES]]
                    [dataset_location [dataset_location ...]]
 
 positional arguments:
@@ -139,20 +139,25 @@ optional arguments:
                         Define the criteria for the checks. Either Strict,
                         Normal, or Lenient. Defaults to Normal.
   --verbose, -v         Increase output. May be specified up to three times.
+  --describe-checks, -D
+                        Describes checks for checkers specified using `-t`. If
+                        `-t` is not specified, lists checks from all available
+                        checkers.
   --skip-checks SKIP_CHECKS, -s SKIP_CHECKS
                         Specifies tests to skip. Can take the form of either
-                        `<check_name>` or `<check_name>:<skip_level>`.  The
-                        first form skips any checks matching the name.  In the
+                        `<check_name>` or `<check_name>:<skip_level>`. The
+                        first form skips any checks matching the name. In the
                         second form <skip_level> may be specified as "A", "M",
-                        or "L".  "A" skips all checks and is equivalent to
+                        or "L". "A" skips all checks and is equivalent to
                         calling the first form. "M" will only show high
                         priority output from the given check and will skip
-                        medium and low.  "L" will show both high and medium
+                        medium and low. "L" will show both high and medium
                         priority issues, while skipping low priority issues.
   -f {text,html,json,json_new}, --format {text,html,json,json_new}
-                        Output format. The difference between the 'json' and
-                        the 'json_new' formats is that the 'json' format has
-                        the check as the top level key, whereas the 'json_new'
+                        Output format(s). Options are 'text', 'html', 'json',
+                        'json_new'. The difference between the 'json' and the
+                        'json_new' formats is that the 'json' format has the
+                        check as the top level key, whereas the 'json_new'
                         format has the dataset name(s) as the main key in the
                         output follow by any checks as subkeys. Also, 'json'
                         format can be only be run against one input file,
@@ -169,7 +174,7 @@ optional arguments:
   -V, --version         Display the IOOS Compliance Checker version
                         information.
   -l, --list-tests      List the available tests
-  -d DOWNLOAD_STANDARD_NAMES, --download-standard-names DOWNLOAD_STANDARD_NAMES
+  -d [DOWNLOAD_STANDARD_NAMES], --download-standard-names [DOWNLOAD_STANDARD_NAMES]
                         Specify a version of the cf standard name table to
                         download as packaged version
 ```

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ parse it's contents.
 usage: cchecker.py [-h] [--test TEST] [--criteria [{lenient,normal,strict}]]
                    [--verbose] [--describe-checks] [--skip-checks SKIP_CHECKS]
                    [-f {text,html,json,json_new}] [-o OUTPUT] [-V] [-l]
-                   [-d [DOWNLOAD_STANDARD_NAMES]]
+                   [-d DOWNLOAD_STANDARD_NAMES]
                    [dataset_location [dataset_location ...]]
 
 positional arguments:
@@ -174,7 +174,7 @@ optional arguments:
   -V, --version         Display the IOOS Compliance Checker version
                         information.
   -l, --list-tests      List the available tests
-  -d [DOWNLOAD_STANDARD_NAMES], --download-standard-names [DOWNLOAD_STANDARD_NAMES]
+  -d DOWNLOAD_STANDARD_NAMES, --download-standard-names DOWNLOAD_STANDARD_NAMES
                         Specify a version of the cf standard name table to
                         download as packaged version
 ```

--- a/cchecker.py
+++ b/cchecker.py
@@ -92,7 +92,7 @@ def main():
     parser.add_argument('-l', '--list-tests', action='store_true',
                         help='List the available tests')
 
-    parser.add_argument('-d', '--download-standard-names', nargs='?',
+    parser.add_argument('-d', '--download-standard-names',
                         help=("Specify a version of the cf standard name table"
                               " to download as packaged version"))
 

--- a/cchecker.py
+++ b/cchecker.py
@@ -8,6 +8,14 @@ from compliance_checker.cf.util import download_cf_standard_name_table
 from compliance_checker import __version__
 from textwrap import dedent
 
+def _print_checker_name_header(checker_str):
+    """
+    Helper function to prints a checker name surrounded by a border of "="
+    :param checker_suite: A check suite string name
+    :type checker: str
+    """
+    print("{0}\n {1} \n{0}".format("=" * (len(checker_str) + 2), checker_str))
+
 
 def main():
     # Load all available checker classes
@@ -32,6 +40,12 @@ def main():
                         help="Increase output. May be specified up to three times.",
                         action="count",
                         default=0)
+
+    parser.add_argument('--describe-checks', '-D',
+                        help=("Describes checks for checkers specified using "
+                              "`-t`. If `-t` is not specified, lists checks "
+                              "from all available checkers."),
+                        action='store_true')
 
     parser.add_argument('--skip-checks', '-s',
                         help=dedent("""
@@ -78,7 +92,7 @@ def main():
     parser.add_argument('-l', '--list-tests', action='store_true',
                         help='List the available tests')
 
-    parser.add_argument('-d', '--download-standard-names',
+    parser.add_argument('-d', '--download-standard-names', nargs='?',
                         help=("Specify a version of the cf standard name table"
                               " to download as packaged version"))
 
@@ -91,7 +105,27 @@ def main():
 
     if args.version:
         print("IOOS compliance checker version %s" % __version__)
-        return 0
+        sys.exit(0)
+
+    if args.describe_checks:
+        error_stat = 0
+        if args.test:
+            checker_names = set(args.test)
+        else:
+            # skip "latest" meta-versions (":latest" or no explicit version
+            # specifier)
+            checker_names = [c for c in check_suite.checkers
+                             if ':' in c and not c.endswith(':latest')]
+
+        for checker_name in sorted(checker_names):
+            if checker_name not in check_suite.checkers:
+                print("Cannot find checker '{}' with which to "
+                      "describe checks".format(checker_name), file=sys.stderr)
+                error_stat = 1
+            else:
+                _print_checker_name_header(checker_name)
+                check_suite._print_checker(check_suite.checkers[checker_name])
+        sys.exit(error_stat)
 
     if args.list_tests:
         print("IOOS compliance checker available checker suites:")
@@ -103,7 +137,7 @@ def main():
 
     if len(args.dataset_location) == 0:
         parser.print_help()
-        return 1
+        sys.exit(1)
 
     # Check the number of output files
     if not args.output:
@@ -144,10 +178,10 @@ def main():
             had_errors.append(errors)
 
     if any(had_errors):
-        return 2
+        sys.exit(2)
     if all(return_values):
-        return 0
-    return 1
+        sys.exit(0)
+    sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -199,7 +199,7 @@ class CheckSuite(object):
         The name of the methods in the Checker class should start with "check_"
         for this method to find them.
         """
-        meths = inspect.getmembers(checkclass, inspect.ismethod)
+        meths = inspect.getmembers(checkclass, inspect.isroutine)
         # return all check methods not among the skipped checks
         returned_checks = []
         for fn_name, fn_obj in meths:


### PR DESCRIPTION
Adds `-D`/`--describe-checks` feature to compliance checker.  This PR represents a squashed, rebased version of the previous draft PR listed in #661, which @daf provided feedback upon.