### PR TITLE
Verify OGC Vert datum name

### DIFF
--- a/compliance_checker/base.py
+++ b/compliance_checker/base.py
@@ -60,7 +60,7 @@ class BaseCheck(object):
         pass
 
     def __init__(self):
-        self._defined_results = defaultdict(lambda: defaultdict(TestCtx))
+        self._defined_results = defaultdict(lambda: defaultdict(dict))
 
     def get_test_ctx(self, severity, name, variable=None):
         """
@@ -75,7 +75,12 @@ class BaseCheck(object):
         :returns: A new or or existing `TestCtx` instance taken from this
                   instance's _defined_results dict
         """
-        return self._defined_results[variable][(severity, name)]
+        # Is it necessary to key out by severity?  Is severity level unique
+        # per check?  If so, it could be eliminated from key hierarchy
+        if severity not in self._defined_results[name][variable]:
+            self._defined_results[name][variable][severity] = \
+             TestCtx(severity, name, variable=variable)
+        return self._defined_results[name][variable][severity]
 
 
 class BaseNCCheck(object):

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -38,6 +38,7 @@ def print_exceptions(f):
             print_exc()
     return wrapper
 
+
 # helper to see if we should do DSG tests
 def is_likely_dsg(func):
     @wraps(func)
@@ -114,6 +115,7 @@ class CFBaseCheck(BaseCheck):
             "9.5": "§9.5 Coordinates and metadata",
             "9.6": "§9.6 Missing Data"
         }
+
 
     ################################################################################
     # Helper Methods - var classifications, etc
@@ -606,7 +608,6 @@ class CF1_6Check(CFNCCheck):
     ###############################################################################
     # Chapter 2: NetCDF Files and Components
     ###############################################################################
-
 
     def check_data_types(self, ds):
         '''
@@ -2778,19 +2779,6 @@ class CF1_6Check(CFNCCheck):
         :return: List of results
         """
 
-        methods = {
-            "point",
-            "sum",
-            "mean",
-            "maximum",
-            "minimum",
-            "mid_range",
-            "standard_deviation",
-            "variance",
-            "mode",
-            "median"
-        }
-
         ret_val = []
         psep = regex.compile(r'(?P<vars>\w+: )+(?P<method>\w+) ?(?P<where>where (?P<wtypevar>\w+) '
                              r'?(?P<over>over (?P<otypevar>\w+))?| ?)(?:\((?P<paren_contents>[^)]*)\))?')
@@ -3629,7 +3617,6 @@ class CF1_7Check(CF1_6Check):
                             "Cell measure variable {} referred to by {} is not present in dataset variables".format(
                                 cell_meas_var_name, var.name)
                         )
-
                     else:
                         valid = True
 

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -3682,9 +3682,8 @@ class CF1_7Check(CF1_6Check):
                                           var_name))
             elif len_vdatum_name_attrs == 1:
                     # should be one or zero attrs
-                    proj_db_path = os.path.join(os.path.dirname(
-                                                     pyproj.__file__),
-                                                'proj_dir/share/proj/proj.db')
+                    proj_db_path = os.path.join(pyproj.datadir.get_data_dir(),
+                                                'proj.db')
                     try:
                         with sqlite3.connect(proj_db_path) as conn:
                             v_datum_attr = next(iter(vert_datum_attrs))

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -3682,11 +3682,11 @@ class CF1_7Check(CF1_6Check):
                                           var_name))
             elif len_vdatum_name_attrs == 1:
                     # should be one or zero attrs
-                    proj_db_path = os.path.join(os.path.dirname(pyproj.__file__),
+                    proj_db_path = os.path.join(os.path.dirname(
+                                                     pyproj.__file__),
                                                 'proj_dir/share/proj/proj.db')
-                    proj_db_loc = "file://{}".format(proj_db_path)
                     try:
-                        with sqlite3.connect(proj_db_loc, uri=True) as conn:
+                        with sqlite3.connect(proj_db_path) as conn:
                             v_datum_attr = next(iter(vert_datum_attrs))
                             v_datum_value = getattr(var, v_datum_attr)
                             v_datum_str_valid = self._process_v_datum_str(

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -3702,7 +3702,7 @@ class CF1_7Check(CF1_6Check):
                         # if we hit an error, skip the check
                         warn("Error occurred while trying to query "
                                         "Proj4 SQLite database at {}: {}"
-                                        .format(proj_db_loc, str(e)))
+                                        .format(proj_db_path, str(e)))
             prev_return[var_name] = test_ctx.to_result()
 
         return prev_return

--- a/compliance_checker/cfutil.py
+++ b/compliance_checker/cfutil.py
@@ -700,10 +700,10 @@ def get_grid_mapping_variables(ds):
 
     :param netCDF4.Dataset ds: An open netCDF4 Dataset
     '''
-    grid_mapping_variables = []
+    grid_mapping_variables = set()
     for ncvar in ds.get_variables_by_attributes(grid_mapping=lambda x: x is not None):
         if ncvar.grid_mapping in ds.variables:
-            grid_mapping_variables.append(ncvar.grid_mapping)
+            grid_mapping_variables.add(ncvar.grid_mapping)
     return grid_mapping_variables
 
 

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -218,9 +218,15 @@ class CheckSuite(object):
         @return list: list of Result objects
         """
         val = check_method(ds)
-        if isinstance(val, list):
+        if hasattr(val, '__iter__'):
+            # Handle OrderedDict when we need to modify results in a superclass
+            # i.e. some checks in CF 1.7 which extend CF 1.6 behaviors
+            if isinstance(val, dict):
+                val_iter = val.values()
+            else:
+                val_iter = val
             check_val = []
-            for v in val:
+            for v in val_iter:
                 res = fix_return_value(v, check_method.__func__.__name__,
                                        check_method, check_method.__self__)
                 if max_level is None or res.weight > max_level:

--- a/compliance_checker/tests/helpers.py
+++ b/compliance_checker/tests/helpers.py
@@ -54,3 +54,7 @@ class MockVariable(object):
             self.ndim = copy_var.ndim
             for att in copy_var.ncattrs():
                 setattr(self, att, getattr(copy_var, att))
+
+    def ncattrs(self):
+        return [att for att in vars(self) if
+                att not in {'ndim', 'name', 'dtype', 'dimensions'}]

--- a/compliance_checker/tests/test_base.py
+++ b/compliance_checker/tests/test_base.py
@@ -108,9 +108,9 @@ class TestBase(TestCase):
         ctx3 = self.acdd.get_test_ctx(base.BaseCheck.HIGH, 'Test Name',
                                       'test_var_name')
         # check that variable cache is working
-        self.assertIs(ctx3, (self.acdd._defined_results['test_var_name']
-                                                       [(base.BaseCheck.HIGH,
-                                                         'Test Name')]
+        self.assertIs(ctx3, (self.acdd._defined_results['Test Name']
+                                                       ['test_var_name']
+                                                       [base.BaseCheck.HIGH]
                                                      ))
 
 

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1379,7 +1379,7 @@ class TestCF1_7(BaseTestCase):
         # WGS84 isn't a valid vertical datum name, of course
         dataset.variables['wgs84'].geopotential_datum_name = 'WGS84'
         del dataset.variables['wgs84'].geoid_name
-        results = self.cf.check_grid_mapping(dataset)
+        results = geopotential_datum_name_bad.check_grid_mapping(dataset)
         self.assertLess(*results['wgs84'].value)
         self.assertIn("Vertical datum value 'WGS84' for attribute 'geopotential_datum_name' in grid mapping variable 'wgs84' is not valid",
                       results['wgs84'].msgs)

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -871,10 +871,10 @@ class TestCF1_6(BaseTestCase):
         dataset = self.load_dataset(STATIC_FILES['mapping'])
         results = self.cf.check_grid_mapping(dataset)
 
-        # there are 8 results, 2 of which did not have perfect scores
-        assert len(results) == 8
-        assert len([r.value for r in results if r.value[0] < r.value[1]]) == 2
-        assert all(r.name == u'§5.6 Horizontal Coorindate Reference Systems, Grid Mappings, Projections' for r in results)
+        assert len(results) == 6
+        assert len([r.value for r in results if r.value[0] < r.value[1]]) == 1
+        expected_name = u'§5.6 Horizontal Coorindate Reference Systems, Grid Mappings, Projections'
+        assert all(r.name == expected_name for r in results)
 
 
     def test_check_geographic_region(self):
@@ -1123,7 +1123,7 @@ class TestCF1_7(TestCF1_6):
 
         dataset = MockTimeSeries()
         dataset.createVariable('a', 'd', ('time',)) # dtype=double, dims=time
-        # test that if the variable doesn't have an actual_range attr, no score 
+        # test that if the variable doesn't have an actual_range attr, no score
         result = self.cf.check_actual_range(dataset)
         assert result == []
         dataset.close()
@@ -1140,7 +1140,7 @@ class TestCF1_7(TestCF1_6):
         assert len(messages) == 1
         assert messages[0] == u"\"a\"'s values are all equal; actual_range shouldn't exist"
         dataset.close()
-        
+
         # test if len(actual_range) != 2; should fail
         dataset = MockTimeSeries()
         dataset.createVariable('a', 'd', ('time',)) # dtype=double, dims=time
@@ -1177,7 +1177,7 @@ class TestCF1_7(TestCF1_6):
         assert len(messages) == 1
         assert messages[0] == "actual_range elements of 'a' inconsistent with its min/max values"
         dataset.close()
-        
+
         # check equality to valid_range attr
         dataset = MockTimeSeries()
         dataset.createVariable('a', 'd', ('time', ))
@@ -1273,7 +1273,7 @@ class TestCF1_7(TestCF1_6):
             dataset.createVariable('PS', 'd', ('time',)) # dtype=double, dims=time
             dataset.variables["PS"].setncattr("cell_measures", 'area: cell_area')
             dataset.setncattr("external_variables", ["cell_area"])
-            
+
             # run the check
             results = self.cf.check_cell_measures(dataset)
             score, out_of, messages = self.get_results(results)

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -877,9 +877,10 @@ class TestCF1_6(BaseTestCase):
         results = self.cf.check_grid_mapping(dataset)
 
         assert len(results) == 6
-        assert len([r.value for r in results if r.value[0] < r.value[1]]) == 1
+        assert len([r.value for r in results.values()
+                    if r.value[0] < r.value[1]]) == 1
         expected_name = u'§5.6 Horizontal Coorindate Reference Systems, Grid Mappings, Projections'
-        assert all(r.name == expected_name for r in results)
+        assert all(r.name == expected_name for r in results.values())
 
 
     def test_check_geographic_region(self):

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -2,8 +2,14 @@
 # -*- coding: utf-8 -*-
 
 from compliance_checker.suite import CheckSuite
-from compliance_checker.cf import CF1_6Check, CF1_7Check, dimless_vertical_coordinates
-from compliance_checker.cf.util import is_vertical_coordinate, is_time_variable, units_convertible, units_temporal, StandardNameTable, create_cached_data_dir, download_cf_standard_name_table
+from compliance_checker.cf import (CF1_6Check, CF1_7Check,
+                                   dimless_vertical_coordinates)
+from compliance_checker.cf.util import (is_vertical_coordinate,
+                                        is_time_variable,
+                                        units_convertible, units_temporal,
+                                        StandardNameTable,
+                                        create_cached_data_dir,
+                                        download_cf_standard_name_table)
 from compliance_checker import cfutil
 from netCDF4 import Dataset
 from tempfile import gettempdir

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pygeoif>=0.6
 netCDF4>=1.4.0
 regex>=2017.07.28
 pendulum>=1.2.4
+pyproj>=2.2.1
 # functools.lru_cache first appears in Python 3.2, use this for other
 # versions
 functools32==3.2.3-2; python_version < '3.2' #conda: functools32  (only python=2)


### PR DESCRIPTION
Adds functionality to check grid mapping attributes for `geoid_name` and `geopotential_datum_name`.

Also overhauls return type for `check_grid_mapping` in both CF 1.6 and 1.7 to use `collections.OrderedDict` instead of `list` so that the 1.7 check can add to the results of the common behavior of the check between 1.6 and 1.7.   This mechanism works with stdout output, but if the raw results are being used by any other programs, the behavior may need to be modified, as iterator over `OrderedDict` will return keys instead of values.  PR is marked as draft as of the time of this writing to allow for discussion about pros/cons and possible other mechanisms for extending checks between different versions of the same checker parent class.