### PR TITLE
ignore global attr starting with EXTRA_DIMENSION

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -517,7 +517,10 @@ class CFBaseCheck(BaseCheck):
         ret_val.append(dimension_naming.to_result())
 
         for global_attr in ds.ncattrs():
+            # Special attributes made by THREDDS
             if global_attr.startswith('DODS'):
+                continue
+            if global_attr.startswith('EXTRA_DIMENSION'):
                 continue
             attribute_naming.assert_true(rname.match(global_attr) is not None,
                                          "global attribute {} should begin with a letter and be composed of "


### PR DESCRIPTION
A THREDDS Server might add global attributes starting with EXTRA_DIMENSION as documented by unidata:
https://www.unidata.ucar.edu/software/netcdf-java/current/CDM/Opendap.html

These global attributes should be ignored by the compliance checker.