### PR TITLE
minor fix in check_grid_mapping; fixes #682

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -2447,8 +2447,8 @@ class CFBaseCheck(BaseCheck):
                                                "{} is a required attribute for grid mapping {}".format(req, grid_mapping_name))
 
             # Make sure that exactly one of the exclusive attributes exist
-            if len(grid_mapping_dict) == 4:
-                at_least_attr = grid_mapping_dict[3]
+            if len(grid_mapping) == 4:
+                at_least_attr = grid_mapping[3]
                 number_found = 0
                 for attr in at_least_attr:
                     if hasattr(grid_var, attr):


### PR DESCRIPTION
Twice replaced `grid_mapping_dict` by `grid_mapping` in function
check_grid_mapping. `grid_mapping` is one element of in
`grid_mapping_dict`. In the two situations, the particular grid mapping
and not the whole dictionary of all grid mappings was to use.