### PR TITLE
Revert conventions multistring

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -139,7 +139,7 @@ class CFBaseCheck(BaseCheck):
         self._find_cf_standard_name_table(ds)
         self._find_geophysical_vars(ds)
 
-    def _check_conventions_version(self, ds):
+    def check_conventions_version(self, ds):
         '''
         CF §2.6.1 the NUG defined global attribute Conventions to the string
         value "CF-<version_number>"; check the Conventions attribute contains
@@ -913,18 +913,18 @@ class CF1_6Check(CFNCCheck):
 
         return valid_fill_range.to_result()
 
-    def check_conventions_are_cf_16(self, ds):
-        '''
-        Check the global attribute conventions to contain CF-1.6.
+    #def check_conventions_are_cf_16(self, ds):
+    #    '''
+    #    Check the global attribute conventions to contain CF-1.6.
 
-        CF §2.6.1 the NUG defined global attribute Conventions to the string
-        value "CF-1.6"
+    #    CF §2.6.1 the NUG defined global attribute Conventions to the string
+    #    value "CF-1.6"
 
-        :param netCDF4.Dataset ds: An open netCDF dataset
-        :rtype: compliance_checker.base.Result
-        '''
+    #    :param netCDF4.Dataset ds: An open netCDF dataset
+    #    :rtype: compliance_checker.base.Result
+    #    '''
 
-        return self._check_conventions_version(ds) # invoke inherited method
+    #    return self.check_conventions_version(ds) # invoke inherited method
 
 
     def check_convention_globals(self, ds):
@@ -3755,18 +3755,18 @@ class CF1_7Check(CF1_6Check):
                                                 v_datum_str))
         return len(res_set.fetchall()) > 0
 
-    def check_conventions_are_cf_1_7(self, ds):
-        '''
-        Check the global attribute conventions to contain CF-1.7.
+    #def check_conventions_are_cf_1_7(self, ds):
+    #    '''
+    #    Check the global attribute conventions to contain CF-1.7.
 
-        CF §2.6.1 the NUG defined global attribute Conventions to the string
-        value "CF-1.7"
+    #    CF §2.6.1 the NUG defined global attribute Conventions to the string
+    #    value "CF-1.7"
 
-        :param netCDF4.Dataset ds: An open netCDF dataset
-        :rtype: compliance_checker.base.Result
-        '''
+    #    :param netCDF4.Dataset ds: An open netCDF dataset
+    #    :rtype: compliance_checker.base.Result
+    #    '''
 
-        return self._check_conventions_version(ds) # invoke inherited method
+    #    return self.check_conventions_version(ds) # invoke inherited method
      
 
 class CFNCCheck(BaseNCCheck, CFBaseCheck):

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -257,17 +257,17 @@ class TestCF1_6(BaseTestCase):
         """
         # :Conventions = "CF-1.6"
         dataset = self.load_dataset(STATIC_FILES['rutgers'])
-        result = self.cf.check_conventions_are_cf_16(dataset)
+        result = self.cf.check_conventions_version(dataset)
         self.assertTrue(result.value)
 
         # :Conventions = "CF-1.6 ,ACDD" ;
         dataset = self.load_dataset(STATIC_FILES['conv_multi'])
-        result = self.cf.check_conventions_are_cf_16(dataset)
+        result = self.cf.check_conventions_version(dataset)
         self.assertTrue(result.value)
 
         # :Conventions = "NoConvention"
         dataset = self.load_dataset(STATIC_FILES['conv_bad'])
-        result = self.cf.check_conventions_are_cf_16(dataset)
+        result = self.cf.check_conventions_version(dataset)
         self.assertFalse(result.value)
         assert result.msgs[0] == (u'§2.6.1 Conventions global attribute does not contain '
                                   '"CF-1.6"')
@@ -1437,17 +1437,17 @@ class TestCF1_7(BaseTestCase):
         # create a temporary variable and test this only
         with MockTimeSeries() as dataset:
             # no Conventions attribute
-            result = self.cf.check_conventions_are_cf_1_7(dataset)
+            result = self.cf.check_conventions_version(dataset)
             self.assertFalse(result.value)
 
         with MockTimeSeries() as dataset:
             # incorrect Conventions attribute
             dataset.setncattr("Conventions", "CF-1.9999")
-            result = self.cf.check_conventions_are_cf_1_7(dataset)
+            result = self.cf.check_conventions_version(dataset)
             self.assertFalse(result.value)
 
         with MockTimeSeries() as dataset:
             # correct Conventions attribute
             dataset.setncattr("Conventions", "CF-1.7, ACDD-1.3")
-            result = self.cf.check_conventions_are_cf_1_7(dataset)
+            result = self.cf.check_conventions_version(dataset)
             self.assertTrue(result.value)


### PR DESCRIPTION
Original interpretation of the CF-1.6 "Conventions" definition implemented in #680 was incongruent with user expectation and interpretation, as @mhidas points out. This PR reverts it, and adds an additional commit which renames `_check_conventions_version()` to `check_conventions_version()`, as the desired behavior is encapsulated within the inherited method.