### PR TITLE
Appendix A attribute check

### DIFF
--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -14,6 +14,7 @@ from netCDF4 import Dataset
 from lxml import etree as ET
 from distutils.version import StrictVersion
 from compliance_checker.base import fix_return_value, Result, GenericFile
+from compliance_checker.cf.cf import CFBaseCheck
 from owslib.sos import SensorObservationService
 from owslib.swe.sensor.sml import SensorML
 from compliance_checker.protocols import opendap, netcdf, cdl
@@ -276,7 +277,7 @@ class CheckSuite(object):
         args = [(name, self.checkers[name]) for name in checker_names if name in self.checkers]
         valid = []
 
-        all_checked = set([a[1] for a in args])  # only class types
+        all_checked = set(a[1] for a in args)  # only class types
         checker_queue = set(args)
         while len(checker_queue):
             name, a = checker_queue.pop()
@@ -359,6 +360,9 @@ class CheckSuite(object):
                     vals.extend(self._run_check(c, ds, max_level))
                 except Exception as e:
                     errs[c.__func__.__name__] = (e, sys.exc_info()[2])
+            if isinstance(checker, CFBaseCheck):
+                for res in checker.appendix_a_results:
+                    vals.append(res)
 
             # score the results we got back
             groups = self.scores(vals)
@@ -750,7 +754,6 @@ class CheckSuite(object):
         @param list raw_scores: list of raw scores (Result objects)
         """
 
-        # BEGIN INTERNAL FUNCS ########################################
         def trim_groups(r):
             if isinstance(r.name, tuple) or isinstance(r.name, list):
                 new_name = r.name[1:]

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -131,7 +131,8 @@ class TestCF1_6(BaseTestCase):
         # delete the dataset and start over to create the variable with _FillValue at time of creation
         del ds
         ds = MockTimeSeries()
-        ds.createVariable("temp", np.float64, dimensions=("time"), fill_value=np.float(99999999999999999999.))
+        ds.createVariable("temp", np.float64, dimensions=("time"),
+                          fill_value=np.float(99999999999999999999.))
 
         # give temp _FillValue as a float, expect good result
         result = self.cf.check_child_attr_data_types(ds)
@@ -153,6 +154,17 @@ class TestCF1_6(BaseTestCase):
         self.assert_result_is_bad(result)
 
         # TODO for CF-1.7: actual_range, actual_min/max
+
+    def test_appendix_a(self):
+        dataset = self.load_dataset(STATIC_FILES['bad_data_type'])
+        self.cf.setup(dataset)
+        aa_results = self.cf.appendix_a_results
+        # institution is in salinity, this shouldn't be present
+        flat_messages = {msg for res in aa_results for msg in res.msgs}
+        self.assertIn('Attribute compress should not be in variable non-coordinate attributes for variable temp. Valid location(s) are [C]',
+                      flat_messages)
+        self.assertIn('Attribute add_offset in variable temp must be a numeric type',
+                      flat_messages)
 
     def test_naming_conventions(self):
         '''
@@ -184,7 +196,6 @@ class TestCF1_6(BaseTestCase):
         assert scored < out_of
         assert len([r for r in results if r.value[0] < r.value[1]]) == 2
         assert all(r.name == u'§2.3 Naming Conventions' for r in results)
-
 
     def test_check_names_unique(self):
         """


### PR DESCRIPTION
Adds checks for attributes, their locations, and types against Appendix A for CF 1.6 and 1.7.

Implements https://cf-trac.llnl.gov/trac/ticket/86 and https://cf-trac.llnl.gov/trac/ticket/87 mentioned in #664