### PR TITLE
add spaces to user messages in check_grid_mapping

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -2454,7 +2454,7 @@ class CFBaseCheck(BaseCheck):
                     if hasattr(grid_var, attr):
                         number_found += 1
                 valid_grid_mapping.assert_true(number_found == 1,
-                                               "grid mapping {}".format(grid_mapping_name) +\
+                                               "grid mapping {} ".format(grid_mapping_name) +\
                                                "must define exactly one of these attributes: "+\
                                                "{}".format(' or '.join(at_least_attr)))
 
@@ -2463,7 +2463,7 @@ class CFBaseCheck(BaseCheck):
             for expected_std_name in expected_std_names:
                 found_vars = ds.get_variables_by_attributes(standard_name=expected_std_name)
                 valid_grid_mapping.assert_true(len(found_vars) == 1,
-                                               "grid mapping {} requires exactly".format(grid_mapping_name)+\
+                                               "grid mapping {} requires exactly ".format(grid_mapping_name)+\
                                                "one variable with standard_name "+\
                                                "{} to be defined".format(expected_std_name))
 


### PR DESCRIPTION
Two error/warning messages, which each consiste of more than one line
of text output, were missing a space between two split lines.