### PR TITLE
penalize 'unidentifiable feature for variable'; fixed #679

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -3225,13 +3225,17 @@ class CFBaseCheck(BaseCheck):
         feature_types_found = defaultdict(list)
         for name in self._find_geophysical_vars(ds):
             feature = cfutil.guess_feature_type(ds, name)
-            # If we can't figure out the feature type, don't penalize, just
-            # make a note of it in the messages
+            # If we can't figure out the feature type, penalize. Originally, 
+            # it was not penalized. However, this led to the issue that the
+            # message did not appear in the output of compliance checker if
+            # no other error/warning/information was printed out for section
+            # 9.1.
             if feature is not None:
                 feature_types_found[feature].append(name)
             else:
-                all_the_same.messages.append("Unidentifiable feature for variable {}"
-                                             "".format(name))
+                all_the_same.assert_true(False,
+                                         "Unidentifiable feature for variable {}"
+                                         "".format(name))
         feature_description = ', '.join(['{} ({})'.format(ftr, ', '.join(vrs)) for ftr, vrs in feature_types_found.items()])
 
         all_the_same.assert_true(len(feature_types_found) < 2,

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -3230,12 +3230,13 @@ class CFBaseCheck(BaseCheck):
             # message did not appear in the output of compliance checker if
             # no other error/warning/information was printed out for section
             # 9.1.
+            found = False
             if feature is not None:
                 feature_types_found[feature].append(name)
-            else:
-                all_the_same.assert_true(False,
-                                         "Unidentifiable feature for variable {}"
-                                         "".format(name))
+                found = True
+            all_the_same.assert_true(found,
+                                     "Unidentifiable feature for variable {}"
+                                     "".format(name))
         feature_description = ', '.join(['{} ({})'.format(ftr, ', '.join(vrs)) for ftr, vrs in feature_types_found.items()])
 
         all_the_same.assert_true(len(feature_types_found) < 2,


### PR DESCRIPTION
If 'unidentifiable feature for variable' arose in the past, it was not
penalized meaning that no individual error was thrown. However, this led
to the issue that the message did not appear in the output of compliance
checker if no other error/warning/information was printed out for
section 9.1. Now, it is regularly penalized and a message appears every
time.