### PR TITLE
mod. check of req. vars with std.name for grid map; fixed #691

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -2462,8 +2462,8 @@ class CFBaseCheck(BaseCheck):
             expected_std_names = grid_mapping[2]
             for expected_std_name in expected_std_names:
                 found_vars = ds.get_variables_by_attributes(standard_name=expected_std_name)
-                valid_grid_mapping.assert_true(len(found_vars) == 1,
-                                               "grid mapping {} requires exactly ".format(grid_mapping_name)+\
+                valid_grid_mapping.assert_true(len(found_vars) >= 1,
+                                               "grid mapping {} requires at least ".format(grid_mapping_name)+\
                                                "one variable with standard_name "+\
                                                "{} to be defined".format(expected_std_name))
 


### PR DESCRIPTION
Modified the checking of the number of variables with specific
attributes required by a grid mapping. Previously `==1` was checked (are
variable with a specific required standard name was allowed to exist
only once). Now, `>=1` is checked (the variable has to exist at least
once). The user output was updated accordingly.