### PR TITLE
Verify grid mapping coordinate vars under CF 1.7

### DIFF
--- a/compliance_checker/tests/data/grid_mapping_coordinates.cdl
+++ b/compliance_checker/tests/data/grid_mapping_coordinates.cdl
@@ -1,0 +1,51 @@
+netcdf example_grid_mapping {
+  dimensions:
+    z = 1 ;
+    y = 1 ;
+    x = 1 ;
+  variables:
+    double x(x) ;
+      x:standard_name = "projection_x_coordinate" ;
+      x:long_name = "Easting" ;
+      x:units = "m" ;
+    double y(y) ;
+      y:standard_name = "projection_y_coordinate" ;
+      y:long_name = "Northing" ;
+      y:units = "m" ;
+    double z(z) ;
+      z:standard_name = "height_above_reference_ellipsoid" ;
+      z:long_name = "height_above_osgb_newlyn_datum_masl" ;
+      z:units = "m" ;
+    double lat(y, x) ;
+      lat:standard_name = "latitude" ;
+      lat:units = "degrees_north" ;
+    double lon(y, x) ;
+      lon:standard_name = "longitude" ;
+      lon:units = "degrees_east" ;
+    float temp(z, y, x) ;
+      temp:standard_name = "air_temperature" ;
+      temp:units = "K" ;
+      temp:coordinates = "lat lon" ;
+      temp:grid_mapping = "crsOSGB: x y crsWGS84: lat lon" ;
+    float pres(z, y, x) ;
+      temp:standard_name = "air_pressure" ;
+      temp:units = "Pa" ;
+      temp:coordinates = "lat lon" ;
+      temp:grid_mapping = "crsOSGB: x y crsWGS84: lat lon" ;
+    int crsOSGB ;
+      crsOSGB:grid_mapping_name = "transverse_mercator";
+      crsOSGB:semi_major_axis = 6377563.396 ;
+      crsOSGB:inverse_flattening = 299.3249646 ;
+      crsOSGB:longitude_of_prime_meridian = 0.0 ;
+      crsOSGB:latitude_of_projection_origin = 49.0 ;
+      crsOSGB:longitude_of_central_meridian = -2.0 ;
+      crsOSGB:scale_factor_at_central_meridian = 0.9996012717 ;
+      crsOSGB:false_easting = 400000.0 ;
+      crsOSGB:false_northing = -100000.0 ;
+      crsOSGB:unit = "metre" ;
+    int crsWGS84 ;
+      crsWGS84:grid_mapping_name = "latitude_longitude";
+      crsWGS84:longitude_of_prime_meridian = 0.0 ;
+      crsWGS84:semi_major_axis = 6378137.0 ;
+      crsWGS84:inverse_flattening = 298.257223563 ;
+}

--- a/compliance_checker/tests/resources.py
+++ b/compliance_checker/tests/resources.py
@@ -52,6 +52,7 @@ STATIC_FILES = {
     'ghrsst'                               : get_filename('tests/data/20160919092000-ABOM-L3S_GHRSST-SSTfnd-AVHRR_D-1d_dn_truncate.cdl'),
     'glcfs'                                : get_filename('tests/data/examples/glcfs.cdl'),
     'grid-boundaries'                      : get_filename('tests/data/grid-boundaries.cdl'),
+    'grid_mapping_coordinates'             : get_filename('tests/data/grid_mapping_coordinates.cdl'),
     'hycom_global'                         : get_filename('tests/data/examples/hycom_global.cdl'),
     'h_point'                              : get_filename('tests/data/appendix_h/point.cdl'),
     'h_timeseries-incomplete'              : get_filename('tests/data/appendix_h/timeseries-incomplete.cdl'),


### PR DESCRIPTION
Verifies that grid mapping coordinate variables that exist as part of a grid_mapping attribute are well formed and exist as variables within the dataset.  Implements https://cf-trac.llnl.gov/trac/ticket/70.