### PR TITLE
Use OWSLib < 0.19.0 for Python 2 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-OWSLib>=0.8.3
+OWSLib>=0.8.3,<0.19.0
 lxml>=3.2.1
 cf_units>=2
 requests>=2.2.1


### PR DESCRIPTION
OWSLib was recently updated. In order to not break the build, constrain the version.