### PR TITLE
Removes Python 2.7 from AppVeyor test matrix due to failures

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,6 @@ build: false
 environment:
   PYTHON: "C:\\myminiconda3"
   matrix:
-    - PY: 2.7
     - PY: 3.8
 
 init:


### PR DESCRIPTION
Should address failures in #705