### PR TITLE
Add option flag to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ parse it's contents.
 ```
 usage: cchecker.py [-h] [--test TEST] [--criteria [{lenient,normal,strict}]]
                    [--verbose] [--describe-checks] [--skip-checks SKIP_CHECKS]
-                   [-f {text,html,json,json_new}] [-o OUTPUT] [-V] [-l]
-                   [-d DOWNLOAD_STANDARD_NAMES]
+                   [-f {text,html,json,json_new}] [-o OUTPUT] [-O OPTION] [-V]
+                   [-l] [-d DOWNLOAD_STANDARD_NAMES]
                    [dataset_location [dataset_location ...]]
 
 positional arguments:
@@ -175,6 +175,16 @@ optional arguments:
                         more than one output file is supplied, the number of
                         input datasets supplied must match the number of
                         output files.
+  -O OPTION, --option OPTION
+                        Additional options to be passed to the checkers.
+                        Multiple options can be specified via multiple
+                        invocations of this switch. Options should be prefixed
+                        with a the checker name followed by the option, e.g.
+                        '<checker>:<option_name>' Available options:
+                        'cf:enable_appendix_a_checks' - Allow check results
+                        against CF Appendix A for attribute location and data
+                        types.
+
   -V, --version         Display the IOOS Compliance Checker version
                         information.
   -l, --list-tests      List the available tests

--- a/cchecker.py
+++ b/cchecker.py
@@ -110,7 +110,13 @@ def main():
                                     via multiple invocations of this switch.
                                     Options should be prefixed with a the
                                     checker name followed by the option, e.g.
-                                    '<checker>:<option_name>'"""))
+                                    '<checker>:<option_name>'
+
+                                    Available options:
+                                    'cf:enable_appendix_a_checks' - Allow check
+                                    results against CF Appendix A for attribute
+                                    location and data types.
+                                    """))
 
     parser.add_argument('-V', '--version', action='store_true',
                         help='Display the IOOS Compliance Checker version information.')

--- a/cchecker.py
+++ b/cchecker.py
@@ -6,7 +6,9 @@ import sys
 from compliance_checker.runner import ComplianceChecker, CheckSuite
 from compliance_checker.cf.util import download_cf_standard_name_table
 from compliance_checker import __version__
+from collections import defaultdict
 from textwrap import dedent
+import warnings
 
 def _print_checker_name_header(checker_str):
     """
@@ -16,6 +18,24 @@ def _print_checker_name_header(checker_str):
     """
     print("{0}\n {1} \n{0}".format("=" * (len(checker_str) + 2), checker_str))
 
+def parse_options(opts):
+    """
+    Helper function to parse possible options.  Splits option after the first
+    colon to split into key/value pairs.
+
+    :param opts: Iterable of strings with options
+    :rtype: dict
+    :return: Dictionary with keys as checker type (i.e. "cf", "acdd")
+    """
+    options_dict = defaultdict(set)
+    for opt_str in opts:
+        try:
+            checker_type, checker_opt = opt_str.split(':', 1)
+        except ValueError:
+            warnings.warn("Could not split option {}, ignoring".format(opt_str))
+        else:
+            options_dict[checker_type].add(checker_opt)
+    return options_dict
 
 def main():
     # Load all available checker classes
@@ -83,6 +103,15 @@ def main():
                               "supplied, the number of input datasets supplied must match "
                               "the number of output files."))
 
+    parser.add_argument('-O', '--option', default=[], action='append',
+                        help=dedent("""
+                                    Additional options to be passed to the
+                                    checkers.  Multiple options can be specified
+                                    via multiple invocations of this switch.
+                                    Options should be prefixed with a the
+                                    checker name followed by the option, e.g.
+                                    '<checker>:<option_name>'"""))
+
     parser.add_argument('-V', '--version', action='store_true',
                         help='Display the IOOS Compliance Checker version information.')
 
@@ -106,6 +135,10 @@ def main():
     if args.version:
         print("IOOS compliance checker version %s" % __version__)
         sys.exit(0)
+
+
+    options_dict = (parse_options(args.option) if args.option else
+                    defaultdict(set))
 
     if args.describe_checks:
         error_stat = 0
@@ -160,7 +193,8 @@ def main():
                                                              args.criteria,
                                                              args.skip_checks,
                                                              args.output[0],
-                                                             args.format or ['text'])
+                                                             args.format or ['text'],
+                                                             options=options_dict)
         return_values.append(return_value)
         had_errors.append(errors)
     else:
@@ -173,7 +207,8 @@ def main():
                                                                 args.criteria,
                                                                 args.skip_checks,
                                                                 output,
-                                                                args.format or ['text'])
+                                                                args.format or ['text'],
+                                                                options=options_dict)
             return_values.append(return_value)
             had_errors.append(errors)
 

--- a/compliance_checker/base.py
+++ b/compliance_checker/base.py
@@ -59,8 +59,12 @@ class BaseCheck(object):
         """
         pass
 
-    def __init__(self):
+    def __init__(self, options=None):
         self._defined_results = defaultdict(lambda: defaultdict(dict))
+        if options is None:
+            self.options = set()
+        else:
+            self.options = options
 
     def get_test_ctx(self, severity, name, variable=None):
         """

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -61,14 +61,14 @@ class CFBaseCheck(BaseCheck):
     CF Convention Checker Base
     """
 
-    def __init__(self):
+    def __init__(self, options=None):
         # The compliance checker can be run on multiple datasets in a single
         # instantiation, so caching values has be done by the unique identifier
         # for each dataset loaded.
 
         # Each default dict is a key, value mapping from the dataset object to
         # a list of variables
-        super(CFBaseCheck, self).__init__()
+        super(CFBaseCheck, self).__init__(options)
         self._coord_vars       = defaultdict(list)
         self._ancillary_vars   = defaultdict(list)
         self._clim_vars        = defaultdict(list)
@@ -891,9 +891,13 @@ class CFBaseCheck(BaseCheck):
         :rtype: list
         :return: A list of results corresponding to the results returned
         """
+        # if 'enable_appendix_a_checks' isn't specified in the checks,
+        # don't do anything on this check
+        results = []
+        if 'enable_appendix_a_checks' not in self.options:
+            return results
         possible_global_atts = (set(ds.ncattrs()).
                                 intersection(self.appendix_a.keys()))
-        results = []
         attr_location_ident = {'G': 'global attributes',
                                'C': 'coordinate data',
                                'D': 'non-coordinate data'}
@@ -1180,8 +1184,8 @@ class CF1_6Check(CFNCCheck):
     }
     appendix_a = appendix_a_base
 
-    def __init__(self): # initialize with parent methods and data
-        super(CF1_6Check, self).__init__()
+    def __init__(self, options=None): # initialize with parent methods and data
+        super(CF1_6Check, self).__init__(options)
 
         self.cell_methods = cell_methods16
         self.grid_mapping_dict = grid_mapping_dict16
@@ -3952,8 +3956,8 @@ class CF1_7Check(CF1_6Check):
         'scale_factor': {'Type': 'N', 'attr_loc': {'D', 'C'}, 'cf_section': '8.1'}
     })
 
-    def __init__(self):
-        super(CF1_7Check, self).__init__()
+    def __init__(self, options=None):
+        super(CF1_7Check, self).__init__(options)
 
         self.cell_methods = cell_methods17
         self.grid_mapping_dict = grid_mapping_dict17

--- a/compliance_checker/runner.py
+++ b/compliance_checker/runner.py
@@ -34,7 +34,7 @@ class ComplianceChecker(object):
     @classmethod
     def run_checker(cls, ds_loc, checker_names, verbose, criteria,
                     skip_checks=None, output_filename='-',
-                    output_format=['text']):
+                    output_format=['text'], options=None):
         """
         Static check runner.
 
@@ -49,7 +49,7 @@ class ComplianceChecker(object):
         @returns                If the tests failed (based on the criteria)
         """
         all_groups = []
-        cs = CheckSuite()
+        cs = CheckSuite(options=options or {})
         # using OrderedDict is important here to preserve the order
         # of multiple datasets which may be passed in
         score_dict = OrderedDict()

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -174,8 +174,10 @@ class TestCF1_6(BaseTestCase):
 
     def test_appendix_a(self):
         dataset = self.load_dataset(STATIC_FILES['bad_data_type'])
+        # Ordinarily, options would be specified in the checker constructor, but
+        # we set them manually here so we don't have to monkey patch `setUp`
+        self.cf.options = {'enable_appendix_a_checks'}
         new_check = copy.deepcopy(self.cf)
-        self.cf.enable_check_appendix_a = True
         self.cf.setup(dataset)
         aa_results = self.cf.check_appendix_a(dataset)
         flat_messages = {msg for res in aa_results for msg in res.msgs}


### PR DESCRIPTION
Adds an `--option`/`-O` flag to the CLI which can pass along additional behavior to individual checkers.

Commits in this PR also disable the CF Appendix A checks by default, but allow them to by turned on by passing `cf:enable_appendix_a_checks` to the aforementioned options.