### PR TITLE
grid mapping false east/north optional; fixed #716

### DIFF
--- a/compliance_checker/cf/appendix_f.py
+++ b/compliance_checker/cf/appendix_f.py
@@ -59,11 +59,12 @@ grid_mapping_dict = {
     'albers_conical_equal_area': [
         (
             'longitude_of_central_meridian',
-            'latitude_of_projection_origin',
+            'latitude_of_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -72,11 +73,12 @@ grid_mapping_dict = {
     'azimuthal_equidistant': [
         (
             'longitude_of_projection_origin',
-            'latitude_of_projection_origin',
+            'latitude_of_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -84,11 +86,12 @@ grid_mapping_dict = {
     ],
     'lambert_cylindrical_equal_area': [
         (
-            'longitude_of_central_meridian',
+            'longitude_of_central_meridian'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -101,11 +104,12 @@ grid_mapping_dict = {
     'lambert_azimuthal_equal_area': [
         (
             'longitude_of_projection_origin',
-            'latitude_of_projection_origin',
+            'latitude_of_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -115,11 +119,12 @@ grid_mapping_dict = {
         (
             'standard_parallel',
             'longitude_of_central_meridian',
-            'latitude_of_projection_origin',
+            'latitude_of_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -135,11 +140,12 @@ grid_mapping_dict = {
     ],
     'mercator': [
         (
-            'longitude_of_projection_origin',
+            'longitude_of_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -152,11 +158,12 @@ grid_mapping_dict = {
     'orthographic': [
         (
             'longitude_of_projection_origin',
-            'latitude_of_projection_origin',
+            'latitude_of_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -165,11 +172,12 @@ grid_mapping_dict = {
     'polar_stereographic': [
         (
             'straight_vertical_longitude_from_pole',
-            'latitude_of_projection_origin',
+            'latitude_of_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -196,11 +204,12 @@ grid_mapping_dict = {
         (
             'longitude_of_projection_origin',
             'latitude_of_projection_origin',
-            'scale_factor_at_projection_origin',
+            'scale_factor_at_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -210,11 +219,12 @@ grid_mapping_dict = {
         (
             'scale_factor_at_central_meridian',
             'longitude_of_central_meridian',
-            'latitude_of_projection_origin',
+            'latitude_of_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -224,11 +234,12 @@ grid_mapping_dict = {
         (
             'longitude_of_projection_origin',
             'latitude_of_projection_origin',
-            'perspective_point_height',
+            'perspective_point_height'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -871,9 +871,11 @@ class TestCF(BaseTestCase):
         dataset = self.load_dataset(STATIC_FILES['mapping'])
         results = self.cf.check_grid_mapping(dataset)
 
-        # there are 8 results, 2 of which did not have perfect scores
+        # there are 8 results, all have perfect scores
+        #  (false_easting does not exist as attribute of grid mapping 
+        #   variable but is optional)
         assert len(results) == 8
-        assert len([r.value for r in results if r.value[0] < r.value[1]]) == 2
+        assert len([r.value for r in results if r.value[0] < r.value[1]]) == 0
         assert all(r.name == u'§5.6 Horizontal Coorindate Reference Systems, Grid Mappings, Projections' for r in results)
 
 


### PR DESCRIPTION
Attributes false_easting and false_northing are now optional for grid
mapping variables. Previously, they were mandatory. The `optional` is
in agreement with CF-1.8. In CF version prior to 1.8 it was ambiguous
whether these attributes were mandatory or not.

Updated cf grid mapping test according to changes.