### PR TITLE
Remove support for Python 2.7 in .travis.yml and requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,8 @@ sudo: false
 matrix:
   fast_finish: true
   include:
-    - name: "default-python2"
-      env: TEST_TARGET=default PY=2.7
     - name: "default-python3"
       env: TEST_TARGET=default PY=3.8
-    - name: "integration-python2"
-      env: TEST_TARGET=integration PY=2.7
     - name: "integration-python3"
       env: TEST_TARGET=integration PY=3.8
     - name: "coding_standards"
@@ -24,8 +20,6 @@ matrix:
     - name: "ugrid plugin"
       env: TEST_TARGET=cc-checker-ugrid PY=3.8
   allow_failures:
-    - name: "integration-python2"
-      env: TEST_TARGET=integration PY=2.7
     - name: "integration-python3"
       env: TEST_TARGET=integration PY=3.8
     - name: "coding_standards"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,3 @@ netCDF4>=1.4.0
 regex>=2017.07.28
 pendulum>=1.2.4
 pyproj>=2.2.1
-# functools.lru_cache first appears in Python 3.2, use this for other
-# versions
-functools32==3.2.3-2; python_version < '3.2' #conda: functools32 (only python=2)


### PR DESCRIPTION
Support for Python 2.7 is no longer needed. References #726 .

