### PR TITLE
grid mapping false east/north optional; fixes #716

### DIFF
--- a/compliance_checker/cf/appendix_f.py
+++ b/compliance_checker/cf/appendix_f.py
@@ -280,6 +280,10 @@ grid_mapping_dict17.update({
         (
             'false_easting',
             'false_northing'
+        ),
+        (
+            'projection_x_coordinate',
+            'projection_y_coordinate'
         )
     ],
     'oblique_mercator': [
@@ -292,6 +296,10 @@ grid_mapping_dict17.update({
         (
             'false_easting',
             'false_northing'
+        ),
+        (
+            'projection_x_coordinate',
+            'projection_y_coordinate'
         )
     ],
     'sinusoidal': [
@@ -301,6 +309,10 @@ grid_mapping_dict17.update({
         (
             'false_easting',
             'false_northing'
+        ),
+        (
+            'projection_x_coordinate',
+            'projection_y_coordinate'
         )
     ]
 })

--- a/compliance_checker/cf/appendix_f.py
+++ b/compliance_checker/cf/appendix_f.py
@@ -81,11 +81,12 @@ grid_mapping_dict16 = {
     'albers_conical_equal_area': [
         (
             'longitude_of_central_meridian',
-            'latitude_of_projection_origin',
+            'latitude_of_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -94,11 +95,12 @@ grid_mapping_dict16 = {
     'azimuthal_equidistant': [
         (
             'longitude_of_projection_origin',
-            'latitude_of_projection_origin',
+            'latitude_of_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -106,11 +108,12 @@ grid_mapping_dict16 = {
     ],
     'lambert_cylindrical_equal_area': [
         (
-            'longitude_of_central_meridian',
+            'longitude_of_central_meridian'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -123,11 +126,12 @@ grid_mapping_dict16 = {
     'lambert_azimuthal_equal_area': [
         (
             'longitude_of_projection_origin',
-            'latitude_of_projection_origin',
+            'latitude_of_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -137,11 +141,12 @@ grid_mapping_dict16 = {
         (
             'standard_parallel',
             'longitude_of_central_meridian',
-            'latitude_of_projection_origin',
+            'latitude_of_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -157,11 +162,12 @@ grid_mapping_dict16 = {
     ],
     'mercator': [
         (
-            'longitude_of_projection_origin',
+            'longitude_of_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -174,11 +180,12 @@ grid_mapping_dict16 = {
     'orthographic': [
         (
             'longitude_of_projection_origin',
-            'latitude_of_projection_origin',
+            'latitude_of_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -187,11 +194,12 @@ grid_mapping_dict16 = {
     'polar_stereographic': [
         (
             'straight_vertical_longitude_from_pole',
-            'latitude_of_projection_origin',
+            'latitude_of_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -218,11 +226,12 @@ grid_mapping_dict16 = {
         (
             'longitude_of_projection_origin',
             'latitude_of_projection_origin',
-            'scale_factor_at_projection_origin',
+            'scale_factor_at_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -232,11 +241,12 @@ grid_mapping_dict16 = {
         (
             'scale_factor_at_central_meridian',
             'longitude_of_central_meridian',
-            'latitude_of_projection_origin',
+            'latitude_of_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -246,11 +256,12 @@ grid_mapping_dict16 = {
         (
             'longitude_of_projection_origin',
             'latitude_of_projection_origin',
-            'perspective_point_height',
+            'perspective_point_height'
+        ),
+        (
             'false_easting',
             'false_northing'
         ),
-        (),
         (
             'projection_x_coordinate',
             'projection_y_coordinate'
@@ -264,7 +275,9 @@ grid_mapping_dict17.update({
         (
             'latitude_of_projection_origin',
             'longitude_of_projection_origin',
-            'perspective_point_height',
+            'perspective_point_height'
+        ),
+        (
             'false_easting',
             'false_northing'
         )
@@ -274,14 +287,18 @@ grid_mapping_dict17.update({
             'azimuth',
             'latitude_of_projection_origin',
             'longitude_of_projection_origin',
-            'scale_factor_at_projection_origin',
+            'scale_factor_at_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         )
     ],
     'sinusoidal': [
         (
-            'longitude_of_projection_origin',
+            'longitude_of_projection_origin'
+        ),
+        (
             'false_easting',
             'false_northing'
         )

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -929,7 +929,7 @@ class TestCF1_6(BaseTestCase):
 
         assert len(results) == 6
         assert len([r.value for r in results.values()
-                    if r.value[0] < r.value[1]]) == 1
+                    if r.value[0] < r.value[1]]) == 0
         expected_name = u'§5.6 Horizontal Coorindate Reference Systems, Grid Mappings, Projections'
         assert all(r.name == expected_name for r in results.values())
 


### PR DESCRIPTION
* grid mapping false east/north optional; fixes #716: Attributes false_easting and false_northing are now optional for grid mapping variables. Previously, they were mandatory. The `optional` is in agreement with CF-1.8. In CF version prior to 1.8 it was ambiguous whether these attributes were mandatory or not.
* added projections_*_coordinate to new projections
* updated grid mapping test according to changes