### PR TITLE
Ioos metadata 1 2

### DIFF
--- a/compliance_checker/tests/test_ioos_profile.py
+++ b/compliance_checker/tests/test_ioos_profile.py
@@ -1,7 +1,10 @@
-from compliance_checker.ioos import IOOS0_1Check, IOOS1_1Check
+from compliance_checker.ioos import IOOS0_1Check, IOOS1_1Check, IOOS1_2Check
 from compliance_checker.tests.resources import STATIC_FILES
 from compliance_checker.tests import BaseTestCase
+from compliance_checker.tests.helpers import MockTimeSeries, MockVariable
+from compliance_checker.tests.test_cf import get_results
 from netCDF4 import Dataset
+import numpy as np
 import os
 
 
@@ -291,3 +294,31 @@ class TestIOOS1_1(BaseTestCase):
         results = self.ioos.check_units(self.ds)
         for result in results:
             self.assert_result_is_good(result)
+
+class TestIOOS1_2(BaseTestCase):
+    '''
+    Tests for the compliance checker implementation of IOOS Metadata Profile
+    for NetCDF, Version 1.1
+    '''
+
+    # for reference
+        #ds.createDimension('siglev', 20)
+
+        #temp = ds.createVariable("temp", np.float64, dimensions=("time",),
+        #                         fill_value=np.float(99999999999999999999.))
+        #temp.coordinates = "sigma noexist"
+        #ds.createVariable("sigma", np.float64, dimensions=('siglev',))
+
+    def setUp(self):
+        self.ioos = IOOS1_2Check() 
+        self.ds = MockTimeSeries() # time, lat, lon, depth 
+
+    def test_check_vars_have_attrs(self):
+
+        # create geophysical variable
+        temp = self.ds.createVariable("temp", np.float64, dimensions=("time",))
+
+        # should fail here
+        results = self.ioos.check_vars_have_attrs(self.ds)
+        scored, out_of, messages = get_results(results)
+        self.assertLess(scored, out_of)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pyproj>=2.2.1
 # functools.lru_cache first appears in Python 3.2, use this for other
 # versions
 functools32==3.2.3-2; python_version < '3.2' #conda: functools32 (only python=2)
+rfc3986>=1.3.2

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
             'ioos_sos = compliance_checker.ioos:IOOSBaseSOSCheck',
             'ioos-0.1 = compliance_checker.ioos:IOOS0_1Check',
             'ioos-1.1 = compliance_checker.ioos:IOOS1_1Check',
+            'ioos-1.2 = compliance_checker.ioos:IOOS1_2Check',
         ]
     },
     package_data         = {


### PR DESCRIPTION
This pull request implements the [IOOS Metadata Profile v1.2](https://ioos.github.io/ioos-metadata/ioos-metadata-profile-v1-2.html) specification as a Checker. Features include:

- adjusting requirement levels for certain global attributes
- ensuring certain attributes are present at the variable-level (`_FillValue, missing_value, standard_name_uri, platform`)
- checking that a dataset can only have a single `platform`
- looking for the `gts_ingest` attribute
- checking instrument variables for the `component` and `discriminant` attributes
- ensuring QARTOD variables include a valid URL as a reference (`qartod_variable:references`)
- enforcing proper length requirements for `wmo_platform_code`

Appropriate unit tests are included.