### PR TITLE
Added features for IOOS Metadata Profile v1.2

### DIFF
--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -8,7 +8,8 @@ from owslib.namespaces import Namespaces
 from lxml.etree import XPath
 from compliance_checker.acdd import ACDD1_3Check
 from compliance_checker.cfutil import (get_geophysical_variables,
-                                       get_instrument_variables)
+                                       get_instrument_variables,
+                                       get_coordinate_variables)
 from compliance_checker import base
 from compliance_checker.cf.cf import CF1_6Check, CF1_7Check
 import validators
@@ -606,13 +607,21 @@ class IOOS1_2Check(IOOSNCCheck):
         """
 
         results = []
-        # NOTE should it also find 'geospatial` variables?
-        for geo_var in get_geophysical_variables(ds):
+
+        # get coordinate and geophysical variables
+        vars_to_check = set(get_geophysical_variables(ds))
+        vars_to_check.update(set(get_coordinate_variables(ds)))
+
+        # NOTE: time is included in coorindate variables, but time
+        # should not be required to have a "platform" attribute.
+        # Potential solutions?
+
+        for var in vars_to_check:
             for attr_tuple in self.check_var_attrs:
                 results.append(
                     self._has_var_attr(
                         ds,
-                        geo_var,
+                        var,
                         attr_tuple[0], # attribute name
                         attr_tuple[0], # attribute name used as 'concept_name'
                         attr_tuple[1]  # priority level

--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -534,6 +534,31 @@ class IOOS1_2Check(IOOSNCCheck):
 
         return self.cf1_7.check_units(ds)
 
+    def check_ioos_ingest(self, ds):
+        """
+        If a dataset contains the global attribute ioos_ingest,
+        its value must be "false". All datasets are assumed to be
+        ingested except those with this flag. If the dataset should
+        be ingested, no flag should be present.
+
+        Parameters
+        ----------
+        ds: netCDF4.Dataset (open)
+
+        Returns
+        -------
+        Result
+        """
+
+        r = True
+        m = "Global attribute \"ioos_ingest\" must be a string with value \"false\""
+        igst = getattr(ds, "ioos_ingest", None)
+        if igst is not None:
+            if igst != "false":
+                r = False
+
+        return Result(BaseCheck.MEDIUM, r, "ioos_ingest", [m])
+
     def check_contributor_role_and_vocabulary(self, ds):
         """
         Check the dataset has global attributes contributor_role and

--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -773,7 +773,7 @@ class IOOS1_2Check(IOOSNCCheck):
             "containing no blank characters; it is {}"
         p = getattr(ds, "platform", None)
         if p:
-            if re.match(r'\w+(?!\s)$', p):
+            if re.match(r'^\S+$', p):
                 r = True
 
         return Result(BaseCheck.HIGH, r, "platform", [m.format(p)])

--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -688,6 +688,30 @@ class IOOS1_2Check(IOOSNCCheck):
 
         return result_list
 
+    def check_platform_global(self, ds):
+        """
+        The "platform" attribute must be a single string containing
+        no blank characters.
+
+        Parameters
+        ----------
+        ds: netCDF4.Dataset (open)
+
+        Returns
+        -------
+        Result
+        """
+
+        r = False
+        m = "The global attribute \"platform\" must be a single string " +\
+            "containing no blank characters; it is {}"
+        p = getattr(ds, "platform", None)
+        if p:
+            if re.match(r'\w+(?!\s)$', p):
+                r = True
+
+        return Result(BaseCheck.HIGH, r, "platform", [m.format(p)])
+
     def check_single_platform(self, ds):
         """
         Verify that a dataset only has a single platform attribute. If one exists,

--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -533,6 +533,70 @@ class IOOS1_2Check(IOOSNCCheck):
 
         return self.cf1_7.check_units(ds)
 
+    def check_contributor_role_and_vocabulary(self, ds):
+        """
+        Check the dataset has global attributes contributor_role and
+        contributor_role_vocabulary. It is recommended to come from
+        one of NERC or GEOIDE.
+
+        Parameters
+        ----------
+        ds: netCDF4.Dataset (open)
+
+        Returns
+        -------
+        list of Result objects
+        """
+
+        # NOTE the URL to GEOIDE is invalid (400), so this only tests
+        # the NERC specification
+
+        role = getattr(ds, "contributor_role", None)
+        vocb = getattr(ds, "contributor_role_vocabulary", None)
+
+        role_val = False
+        vocb_val = False
+
+        role_msg = "contributor_role should be from NERC or GEOIDE"
+        vocb_msg = "contributor_role_vocabulary should be one of NERC or GEOIDE"
+
+        if role:
+            if role in [
+                "author",
+                "coAuthor",
+                "collaborator",
+                "contributor",
+                "custodian",
+                "distributor",
+                "editor",
+                "funder",
+                "mediator",
+                "originator",
+                "owner",
+                "pointOfContact",
+                "principalInvestigator",
+                "processor",
+                "publisher",
+                "resourceProvider",
+                "rightsHolder",
+                "sponsor",
+                "stakeholder",
+                "user"
+            ]:
+                role_val = True
+
+        if vocb:
+            if vocb in [
+                "http://vocab.nerc.ac.uk/collection/G04/current/",
+                "https://geo-ide.noaa.gov/wiki/index.php?title=ISO_19115_and_19115-2_CodeList_Dictionaries#CI_RoleCode"
+            ]:
+                vocb_val = True
+
+        return [
+            Result(BaseCheck.MEDIUM, role_val, "contributor_role", [role_msg]),
+            Result(BaseCheck.MEDIUM, vocb_val, "contributor_role_vocabulary", [vocb_msg]),
+        ]
+
     def check_vars_have_attrs(self, ds):
         """
         Using the tuples defined in __init__, check that each variable has

--- a/compliance_checker/tests/helpers.py
+++ b/compliance_checker/tests/helpers.py
@@ -21,11 +21,11 @@ class MockTimeSeries(MockNetCDF):
     Mock time series with time dimension and time, lon, lat, and depth
     variables defined
     """
-    def __init__(self):
+    def __init__(self, default_fill_value=None):
         super(MockTimeSeries, self).__init__()
         self.createDimension('time', 500)
         for v in ('time', 'lon', 'lat', 'depth'):
-            self.createVariable(v, 'd', ('time',))
+            self.createVariable(v, 'd', ('time',), fill_value=default_fill_value)
 
         # give some applicable units
         self.variables["time"].units  = "seconds since 2019-04-11T00:00:00"

--- a/compliance_checker/tests/test_ioos_profile.py
+++ b/compliance_checker/tests/test_ioos_profile.py
@@ -576,6 +576,24 @@ class TestIOOS1_2(BaseTestCase):
         score, out_of = results[0].value
         self.assertEqual(score, out_of)
 
+    def test_check_platform_global(self):
+        ds = MockTimeSeries() # time, lat, lon, depth 
+
+        # no global attr, fail
+        self.assertFalse(self.ioos.check_platform_global(ds).value)
+
+        # bad global attr, fail
+        ds.setncattr("platform", "bad value")
+        self.assertFalse(self.ioos.check_platform_global(ds).value)
+
+        # another bad value
+        ds.setncattr("platform", " bad")
+        self.assertFalse(self.ioos.check_platform_global(ds).value)
+
+        # good value
+        ds.setncattr("platform", "single_string")
+        self.assertTrue(self.ioos.check_platform_global(ds).value)
+
     def test_check_single_platform(self):
 
         ds = MockTimeSeries() # time, lat, lon, depth 

--- a/compliance_checker/tests/test_ioos_profile.py
+++ b/compliance_checker/tests/test_ioos_profile.py
@@ -673,3 +673,21 @@ class TestIOOS1_2(BaseTestCase):
         qr.setncattr("references", r"p9q384ht09q38@@####???????////??//\/\/\/\//\/\74ht")
         results = self.ioos.check_qartod_variables_references(ds)
         self.assertFalse(all(r.value for r in results))
+
+    def test_check_ioos_ingest(self):
+        ds = MockTimeSeries()
+
+        # no value, pass
+        self.assertTrue(self.ioos.check_ioos_ingest(ds).value)
+
+        # value false
+        ds.setncattr("ioos_ingest", "false")
+        self.assertTrue(self.ioos.check_ioos_ingest(ds).value)
+
+        # value anything but false
+        ds.setncattr("ioos_ingest", "true")
+        self.assertFalse(self.ioos.check_ioos_ingest(ds).value)
+        ds.setncattr("ioos_ingest", 0)
+        self.assertFalse(self.ioos.check_ioos_ingest(ds).value)
+        ds.setncattr("ioos_ingest", "False")
+        self.assertFalse(self.ioos.check_ioos_ingest(ds).value)

--- a/compliance_checker/tests/test_ioos_profile.py
+++ b/compliance_checker/tests/test_ioos_profile.py
@@ -317,13 +317,19 @@ class TestIOOS1_2(BaseTestCase):
         self.assertLess(scored, out_of)
 
         # should pass
-        ds = MockTimeSeries() # time, lat, lon, depth
+        ds = MockTimeSeries(default_fill_value=9999999999.) # time, lat, lon, depth 
         temp = ds.createVariable("temp", np.float64, fill_value=9999999999.) # _FillValue
         temp.setncattr("missing_value", 9999999999.)
         temp.setncattr("standard_name", "sea_surface_temperature")
         temp.setncattr("standard_name_uri", "http://cfconventions.org/Data/cf-standard-names/64/build/cf-standard-name-table.html")
         temp.setncattr("units", "degree_C")
         temp.setncattr("platform", "myPlatform")
+
+        ds.variables["time"].setncattr("platform", "myPlatform")
+        ds.variables["time"].setncattr("standard_name", "time")
+        ds.variables["time"].setncattr("standard_name_uri", "time")
+        ds.variables["time"].setncattr("units", "hours since 1970-01-01T00:00:00")
+        ds.variables["time"].setncattr("missing_value", 9999999999.)
 
         results = self.ioos.check_vars_have_attrs(ds)
         scored, out_of, messages = get_results(results)

--- a/compliance_checker/tests/test_ioos_profile.py
+++ b/compliance_checker/tests/test_ioos_profile.py
@@ -395,16 +395,25 @@ class TestIOOS1_2(BaseTestCase):
         self.assertEqual(scored, out_of)
 
         # give one variable the gts_ingest attribute
+        # no ancillary vars, should fail
         ds.variables["time"].setncattr("gts_ingest", "true")
         results = self.ioos.check_gts_ingest(ds)
         scored, out_of, messages = get_results(results)
-        self.assertEqual(scored, out_of)
+        self.assertLess(scored, out_of)
 
-        # give a poor value
-        ds.variables["time"].setncattr("gts_ingest", "blah")
+        # set ancillary var with bad standard name
+        tmp = ds.createVariable("tmp", np.byte, ("time",))
+        tmp.setncattr("standard_name", "bad")
+        ds.variables["time"].setncattr("ancillary_variables", "tmp")
         results = self.ioos.check_gts_ingest(ds)
         scored, out_of, messages = get_results(results)
         self.assertLess(scored, out_of)
+
+         # good ancillary var standard name
+        tmp.setncattr("standard_name", "aggregate_quality_flag")
+        results = self.ioos.check_gts_ingest(ds)
+        scored, out_of, messages = get_results(results)
+        self.assertEqual(scored, out_of)
 
     def test_check_instrument_variables(self):
 
@@ -550,6 +559,61 @@ class TestIOOS1_2(BaseTestCase):
         results = self.ioos.check_platform_variable_cf_role(ds)
         score, out_of = results[0].value
         self.assertEqual(score, out_of)
+
+    def test_check_single_platform(self):
+
+        ds = MockTimeSeries() # time, lat, lon, depth 
+
+        # no global attr but also no platform variables, should pass
+        results = self.ioos.check_single_platform(ds)
+        self.assertTrue(results[0].value)
+
+        # give platform global, no variables, fail
+        ds.setncattr("platform", "buoy")
+        results = self.ioos.check_single_platform(ds)
+        self.assertFalse(results[0].value)
+
+        # global attribute, one platform variable, correct cf_role & featureType, pass
+        ds.setncattr("featureType", "profile")
+        ds.createDimension("profile", 1)
+        temp = ds.createVariable("temp", "d", ("time"))
+        temp.setncattr("platform", "platform_var")
+        plat = ds.createVariable("platform_var", np.byte)
+        cf_role_var = ds.createVariable("cf_role_var", np.byte, ("profile",))
+        cf_role_var.setncattr("cf_role", "timeseries_id")
+        results = self.ioos.check_single_platform(ds)
+        self.assertTrue(all(r.value for r in results))
+
+        # global attr, multiple platform variables, correct cf_role & featureType, fail
+        plat2 = ds.createVariable("platform_var_2", np.byte)
+        temp2 = ds.createVariable("temp2", "d", ("time"))
+        temp2.setncattr("platform", "platform_var2")
+        results = self.ioos.check_single_platform(ds)
+        self.assertFalse(results[0].value)
+
+        # no global attr, one platform var, correct cf_role & featureType, fail
+        ds.delncattr("platform")
+        self.assertFalse(results[0].value)
+
+        # global attr, one platform var, correct featureType, incorrect cf_role var dimension
+        ds = MockTimeSeries() # time, lat, lon, depth 
+        ds.setncattr("featureType", "trajectoryprofile")
+        ds.createDimension("trajectory", 2) # should only be 1
+        temp = ds.createVariable("temp", "d", ("time"))
+        temp.setncattr("platform", "platform_var")
+        plat = ds.createVariable("platform_var", np.byte)
+        cf_role_var = ds.createVariable("cf_role_var", np.byte, ("trajectory",))
+        cf_role_var.setncattr("cf_role", "trajectory_id")
+        results = self.ioos.check_single_platform(ds)
+        self.assertFalse(results[0].value)
+
+    def test_check_platform_vocabulary(self):
+        ds = MockTimeSeries() # time, lat, lon, depth 
+        ds.setncattr("platform_vocabulary", "http://google.com")
+        self.assertTrue(self.ioos.check_platform_vocabulary(ds).value)
+
+        ds.setncattr("platform_vocabulary", "bad")
+        self.assertFalse(self.ioos.check_platform_vocabulary(ds).value)
 
     def test_check_qartod_variables_references(self):
         ds = MockTimeSeries() # time, lat, lon, depth

--- a/compliance_checker/tests/test_ioos_profile.py
+++ b/compliance_checker/tests/test_ioos_profile.py
@@ -305,18 +305,18 @@ class TestIOOS1_2(BaseTestCase):
     def setUp(self):
         self.ioos = IOOS1_2Check()
 
-    def test_check_vars_have_attrs(self):
+    def test_check_geophysical_vars_have_attrs(self):
 
         # create geophysical variable
         ds = MockTimeSeries() # time, lat, lon, depth
         temp = ds.createVariable("temp", np.float64, dimensions=("time",))
 
         # should fail here
-        results = self.ioos.check_vars_have_attrs(ds)
+        results = self.ioos.check_geophysical_vars_have_attrs(ds)
         scored, out_of, messages = get_results(results)
         self.assertLess(scored, out_of)
 
-        # should pass
+        # set the necessary attributes
         ds = MockTimeSeries(default_fill_value=9999999999.) # time, lat, lon, depth 
         temp = ds.createVariable("temp", np.float64, fill_value=9999999999.) # _FillValue
         temp.setncattr("missing_value", 9999999999.)
@@ -325,13 +325,30 @@ class TestIOOS1_2(BaseTestCase):
         temp.setncattr("units", "degree_C")
         temp.setncattr("platform", "myPlatform")
 
-        ds.variables["time"].setncattr("platform", "myPlatform")
+        results = self.ioos.check_geophysical_vars_have_attrs(ds)
+        scored, out_of, messages = get_results(results)
+        self.assertEqual(scored, out_of)
+
+    def test_check_geospatial_vars_have_attrs(self):
+
+        # create geophysical variable
+        ds = MockTimeSeries() # time, lat, lon, depth 
+        temp = ds.createVariable("temp", np.float64, dimensions=("time",))
+
+        # should fail here
+        results = self.ioos.check_geospatial_vars_have_attrs(ds)
+        scored, out_of, messages = get_results(results)
+        self.assertLess(scored, out_of)
+
+        # should pass - default_fill_value sets _FillValue attr
+        ds = MockTimeSeries(default_fill_value=9999999999.) # time, lat, lon, depth 
+
         ds.variables["time"].setncattr("standard_name", "time")
         ds.variables["time"].setncattr("standard_name_uri", "time")
         ds.variables["time"].setncattr("units", "hours since 1970-01-01T00:00:00")
         ds.variables["time"].setncattr("missing_value", 9999999999.)
 
-        results = self.ioos.check_vars_have_attrs(ds)
+        results = self.ioos.check_geospatial_vars_have_attrs(ds)
         scored, out_of, messages = get_results(results)
         self.assertEqual(scored, out_of)
 


### PR DESCRIPTION
Checks the following:
 - `gts_ingest` (global and variable)
 - `contributor_role` and `contributor_role_vocabulary`
 - geospatial (coordinate) variables as well as geophysical variables
 - explicit check for `platform` global attribute
 - explicit check for `platform` variable attribute, with routine to examine shape of dimension variables
 - ensure both geophysical and geospatial variables meet respective requirements

Commit 34f5c02 enables users to supply a default `_FillValue` while constructing a `MockTimeSeries`. This can make testing the `FillValue` possible for coordinate variables, e.g. `time`. I am open to cherry-picking this commit into its own feature branch if that's desired.