### PR TITLE
Fix variable print-out bug

### DIFF
--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -962,7 +962,7 @@ class IOOS1_2Check(IOOSNCCheck):
                    " must fulfill the following:\n"
                    "  - must be a string with value \"true\" or \"false\";\n"
                    "  - have a valid CF standard_name attribute (already checked);\n"
-                   "  - have an ancillary variable reqpresenting QARTOD aggregate flags;\n"
+                   "  - have an ancillary variable representing QARTOD aggregate flags;\n"
                    "  - have a valid udunits units attribute\n"
                    "The global attribute \"gts_ingest\" "
                    "must also have a value of \"true\".")

--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -958,7 +958,7 @@ class IOOS1_2Check(IOOSNCCheck):
             results.append(default_pass_result)
 
         # check variables
-        var_msg = ("The attribute \"gts_ingest\" of variable \"{v}\" "
+        var_msg = ("The attribute \"gts_ingest\" of variable \"{v.name}\" "
                    " must fulfill the following:\n"
                    "  - must be a string with value \"true\" or \"false\";\n"
                    "  - have a valid CF standard_name attribute (already checked);\n"


### PR DESCRIPTION
The `gts_ingest` check accidentally prints out the `netCDF4` string representation of the variables it's looking at instead of the name:

```
                               Highly Recommended                               
--------------------------------------------------------------------------------
gts_ingest variable
* The attribute "gts_ingest" of variable "<class 'netCDF4._netCDF4.Variable'>
float64 s.air_temperature(s)
    _ChunkSizes: [240760      1]
    _FillValue: -9999.0
    actual_range: [ 2.16 34.8 ]
    ancillary_variables: air_temperature_qc_agg air_temperature_qc_tests
    gts_ingest: true
    id: 1000735
    ioos_category: Other
    long_name: Air Temperature
    missing_value: -9999.0
    platform: station
    standard_name: air_temperature
    standard_name_uri: http://mmisw.org/ont/cf/parameter/air_temperature
```

This commit uses the name instead:

```
gts_ingest variable
* The attribute "gts_ingest" of variable "s.air_temperature"  must fulfill the following:
  - must be a string with value "true" or "false";
  - have a valid CF standard_name attribute (already checked);
  - have an ancillary variable reqpresenting QARTOD aggregate flags;
  - have a valid udunits units attribute
```