### PR TITLE
Ioos  1 2  redundant msgs

### DIFF
--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -451,8 +451,6 @@ class IOOS1_2Check(IOOSNCCheck):
         self.rec_atts = [
             ('contributor_email', base.EmailValidator()),
             'contributor_name',
-            'contributor_role',
-            'contributor_role_vocabulary',
             ('contributor_url', base.UrlValidator(base.csv_splitter)),
             'creator_address',
             'creator_city',

--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -462,7 +462,6 @@ class IOOS1_2Check(IOOSNCCheck):
             #'creator_type',
             'institution',
             'instrument',
-            'ioos_ingest',
             'keywords',
             'platform_id',
             'publisher_address',


### PR DESCRIPTION
Remove redundant messages for `contributor_role`, `contributor_role_vocabulary`, and `ioos_ingest`. Each has an explicit check, so they are not needed in the recommended attributes.