### PR TITLE
Improved check for platform

### DIFF
--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -832,24 +832,24 @@ class IOOS1_2Check(IOOSNCCheck):
         if num_platforms > 1 and glb_platform:
             msg = "A dataset may only have one platform; {} found".format(len(platform_set))
             val = False
-            results.append(Result(BaseCheck.HIGH, val, "platform", [msg]))
+            results.append(Result(BaseCheck.HIGH, val, "platform", [msg] if not val else []))
 
         elif ((not glb_platform) and num_platforms > 0):
             msg = "If platform variables exist, a global attribute \"platform\" must also exist"
             val = False
-            results.append(Result(BaseCheck.HIGH, val, "platform", [msg]))
+            results.append(Result(BaseCheck.HIGH, val, "platform", [msg] if not val else []))
 
         elif num_platforms == 0 and glb_platform:
             msg = "A dataset with a global \"platform\" attribute must have platform variables"
             val = False
-            results.append(Result(BaseCheck.HIGH, val, "platform", [msg]))
+            results.append(Result(BaseCheck.HIGH, val, "platform", [msg] if not val else []))
 
         elif num_platforms == 0 and (not glb_platform):
             # can't determine if the data should actually have a platform or not,
             # so this must result in a pass
             msg = "Gridded model datasets are not required to declare a platform"
             val = True
-            results.append(Result(BaseCheck.HIGH, val, "platform", [msg]))
+            results.append(Result(BaseCheck.HIGH, val, "platform", [msg] if not val else []))
 
         else: # num_platforms==1 and glb_platform
 
@@ -902,7 +902,14 @@ class IOOS1_2Check(IOOSNCCheck):
                            BaseCheck.HIGH,
                            _val,
                            "platform variables",
-                           [msg.format(cf_role_var=var.name, cf_role=cf_role, dim=shp, featureType=feature_type)]
+                           [
+                               msg.format(
+                                   cf_role_var=var.name,
+                                   cf_role=cf_role,
+                                   dim=shp,
+                                   featureType=feature_type
+                               )
+                           ] if not _val else []
                        )
                     )
 

--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -777,8 +777,8 @@ class IOOS1_2Check(IOOSNCCheck):
            if not isinstance(plid, str):
                 r = False
 
-        m = "The \"platform_id\" attribute is {} of type {}; " +\
-            "it must be a string"
+        m = ("The \"platform_id\" attribute is {} of type {}; "
+            "it must be a string")
         return Result(BaseCheck.MEDIUM, r, "platform_id", [m.format(plid, type(plid))])
 
     def _check_platform_is_str(self, p):
@@ -795,13 +795,10 @@ class IOOS1_2Check(IOOSNCCheck):
         Result
         """
 
-        m = "Global attribute \"platform\" must be a string containing no spaces; " +\
-            "it is \"{}\""
-        r = True
-        if not (isinstance(p, str) and re.match(r'^\S+$', p)):
-            r = False
+        m = ("Global attribute \"platform\" must be a string containing no spaces; "
+            "it is \"{}\"")
 
-        return Result(BaseCheck.HIGH, r, "platform", [m.format(p)])
+        return Result(BaseCheck.HIGH, (isinstance(p, str) and re.match(r'^\S+$', p)), "platform", [m.format(p)])
 
     def check_single_platform(self, ds):
         """


### PR DESCRIPTION
Consolidate methods and improve clarity of message.
When the dataset has the proper number of platform variables
and the global platform variable is set, test the platform_name,
platform_id, and platform_vocabulary attributes. These attributes
are otherwise not applicable.

This commit also removes redundant messaging.