### PR TITLE
Fix lack of messages where ValidatorObject is used

### DIFF
--- a/compliance_checker/base.py
+++ b/compliance_checker/base.py
@@ -465,7 +465,7 @@ def attr_check(kvp, ds, priority, ret_val, gname=None, var_name=None):
         else:
             check_val = attr_result[1]
             res_tup = other.validate(name, check_val)
-            msgs = [] if res_tup[1] is None else [res_tup[1]]
+        msgs = [] if res_tup[1] is None else res_tup[1]
         ret_val.append(
             Result(
                 priority,


### PR DESCRIPTION
Some metadata fields like "contributor_email" were not being
populated with messages; fix this to the desired behavior.

Example

Current behavior:

```
                                  Recommended                                   
--------------------------------------------------------------------------------
contributor_email

contributor_name
* contributor_name not present

contributor_role
* contributor_role should be from NERC or GEOIDE
* contributor_role not present

contributor_role_vocabulary
* contributor_role_vocabulary should be one of NERC or GEOIDE
* contributor_role_vocabulary not present

contributor_url

```

Improved behavior:

```
                                  Recommended                                   
--------------------------------------------------------------------------------
contributor_email
* contributor_email not present

contributor_name
* contributor_name not present

contributor_role
* contributor_role should be from NERC or GEOIDE
* contributor_role not present

contributor_role_vocabulary
* contributor_role_vocabulary should be one of NERC or GEOIDE
* contributor_role_vocabulary not present

contributor_url
* contributor_url not present
```