### PR TITLE
Ensure platform_id is an alphanumeric string

### DIFF
--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -466,7 +466,7 @@ class IOOS1_2Check(IOOSNCCheck):
             'instrument',
             'ioos_ingest',
             'keywords',
-            'platform_id',
+            ('platform_id', re.compile(r"^\w+$")), # alphanumeric only
             'publisher_address',
             'publisher_city',
             'publisher_name',

--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -358,6 +358,10 @@ class IOOS1_2_ConventionsValidator(base.RegexValidator):
     validator_regex = r"\bIOOS-1.2\b"
     validator_fail_msg = "{} must contain the string \"IOOS 1.2\""
 
+class IOOS1_2_PlatformIDValidator(base.RegexValidator):
+    validator_regex = r"^\w+$"
+    validator_fail_msg = "{} must be alphanumeric"
+
 class NamingAuthorityValidator(base.UrlValidator):
     """
     Class to check for URL or reversed DNS strings contained within
@@ -466,7 +470,7 @@ class IOOS1_2Check(IOOSNCCheck):
             'instrument',
             'ioos_ingest',
             'keywords',
-            ('platform_id', re.compile(r"^\w+$")), # alphanumeric only
+            ('platform_id', IOOS1_2_PlatformIDValidator()), # alphanumeric only
             'publisher_address',
             'publisher_city',
             'publisher_name',

--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -359,7 +359,7 @@ class IOOS1_2_ConventionsValidator(base.RegexValidator):
     validator_fail_msg = "{} must contain the string \"IOOS 1.2\""
 
 class IOOS1_2_PlatformIDValidator(base.RegexValidator):
-    validator_regex = r"^\w+$"
+    validator_regex = r"^[a-zA-Z0-9]+$"
     validator_fail_msg = "{} must be alphanumeric"
 
 class NamingAuthorityValidator(base.UrlValidator):

--- a/compliance_checker/tests/test_ioos_profile.py
+++ b/compliance_checker/tests/test_ioos_profile.py
@@ -1,5 +1,6 @@
 from compliance_checker.ioos import (IOOS0_1Check, IOOS1_1Check, IOOS1_2Check,
-                                     NamingAuthorityValidator)
+                                     NamingAuthorityValidator,
+                                     IOOS1_2_PlatformIDValidator)
 from compliance_checker.tests.resources import STATIC_FILES
 from compliance_checker.tests import BaseTestCase
 from compliance_checker.tests.helpers import MockTimeSeries, MockVariable
@@ -569,6 +570,24 @@ class TestIOOS1_2(BaseTestCase):
         self.assertEqual(bad_result[1],
                          "naming_authority should either be a URL or a "
                          "reversed DNS name (e.g \"edu.ucar.unidata\")")
+
+    def test_platform_id_validation(self):
+        attn = "platform_id"
+        attv = "alphaNum3R1C"
+        v = IOOS1_2_PlatformIDValidator()
+        self.assertTrue(v.validate(attn, attv)[0])
+        
+        attv = "alpha"
+        v = IOOS1_2_PlatformIDValidator()
+        self.assertTrue(v.validate(attn, attv)[0])
+
+        attv = "311123331112"
+        v = IOOS1_2_PlatformIDValidator()
+        self.assertTrue(v.validate(attn, attv)[0])
+
+        attv = "---fail---"
+        v = IOOS1_2_PlatformIDValidator()
+        self.assertFalse(v.validate(attn, attv)[0])
 
     def test_check_platform_cf_role(self):
         """


### PR DESCRIPTION
This addresses #762 quite succinctly, but I'm worried that the error message at 

https://github.com/ioos/compliance-checker/blob/54b5300663b70e586ca429e2ecdad12f0e155314/compliance_checker/base.py#L488

is going to be quite unclear to some users. I'm going to ping for @benjwadams for some insight. The machinery is already here, which makes a pull request this simple so tempting.