### PR TITLE
Ensure wmo_platform_code conforms to specification

### DIFF
--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -1063,7 +1063,7 @@ class IOOS1_2Check(IOOSNCCheck):
                isinstance(code, str) and
                (
                    (code.isnumeric() and (len(code)==5 or len(code)==7)) or
-                   re.search(r"^\w{5}$", code)
+                   re.search(r"^(?:[a-zA-Z0-9]{5}|[0-9]{7})$", code)
                )
            ):
                valid = False

--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -1062,7 +1062,6 @@ class IOOS1_2Check(IOOSNCCheck):
            if not (
                isinstance(code, str) and
                (
-                   (code.isnumeric() and (len(code)==5 or len(code)==7)) or
                    re.search(r"^(?:[a-zA-Z0-9]{5}|[0-9]{7})$", code)
                )
            ):

--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -1034,9 +1034,16 @@ class IOOS1_2Check(IOOSNCCheck):
 
     def check_wmo_platform_code(self, ds):
         """
-        If a WMO Platform Code is given as a global variable, check that it is
-        well-formed. According to the WMO, valid codes are a numeric string
-        comprised of 5 or 7 characters.
+        Per the spec:
+
+        "The WMO identifier for the platform used to measure the data. This
+        identifier can be any of the following types:
+          - WMO ID for buoys (numeric, 5 digits)
+          - WMO ID for gliders (numeric, 7 digits)
+          - NWS ID (alphanumeric, 5 digits)"
+
+        This attribute is "required, if applicable" -- a warning message will
+        only show up if the attribute is present and does not conform.
 
         Args:
             ds (netCDF4.Dataset): open Dataset
@@ -1047,14 +1054,17 @@ class IOOS1_2Check(IOOSNCCheck):
 
         valid = True
         ctxt = "wmo_platform_code"
-        msg = "The wmo_platform_code must be a numeric string of 5 or 7 characters"
+        msg = ("The wmo_platform_code must be an alphanumeric string of 5 "
+               "characters or a numeric string of 7 characters")
 
         code = getattr(ds, "wmo_platform_code", None)
         if code:
            if not (
                isinstance(code, str) and
-               code.isnumeric() and
-               (5 <= len(code) <= 7)
+               (
+                   (code.isnumeric() and (len(code)==5 or len(code)==7)) or
+                   re.search(r"^\w{5}$", code)
+               )
            ):
                valid = False
 

--- a/compliance_checker/tests/test_ioos_profile.py
+++ b/compliance_checker/tests/test_ioos_profile.py
@@ -507,13 +507,18 @@ class TestIOOS1_2(BaseTestCase):
         result = self.ioos.check_wmo_platform_code(ds)
         self.assertTrue(result.value)
 
-        # non-numeric, fail
+        # alphanumeric, valid
         ds.setncattr("wmo_platform_code", "abcd1")
         result = self.ioos.check_wmo_platform_code(ds)
-        self.assertFalse(result.value)
+        self.assertTrue(result.value)
 
         # invalid length, fail
         ds.setncattr("wmo_platform_code", "123")
+        result = self.ioos.check_wmo_platform_code(ds)
+        self.assertFalse(result.value)
+
+        # alphanumeric len 7, fail
+        ds.setncattr("wmo_platform_code", "1a2b3c7")
         result = self.ioos.check_wmo_platform_code(ds)
         self.assertFalse(result.value)
 


### PR DESCRIPTION
Addresses #760 (in part, see bottom of discussion; other parts are being addressed separately). Ensure the `wmo_platform_code` conforms to the specification of

  - numeric string of 5 or 7 characters
  - alphanumeric strings of 5 characters

This is corresponds with the [specification](https://ioos.github.io/ioos-metadata/ioos-metadata-profile-v1-2.html#platform) (see "wmo_platform_code" in the table).