### PR TITLE
Change num2date to num2pydate

### DIFF
--- a/compliance_checker/acdd.py
+++ b/compliance_checker/acdd.py
@@ -6,7 +6,7 @@ project for the verification and scoring of attributes for datasets.
 '''
 
 import numpy as np
-from netCDF4 import num2date
+from cftime import num2pydate
 from datetime import timedelta
 from compliance_checker.base import (BaseCheck, BaseNCCheck, check_has,
                                      Result, ratable_result)
@@ -536,9 +536,9 @@ class ACDDBaseCheck(BaseCheck):
             # subtraction from t_min/t_max will assume that a naive timestamp is
             # in the same time zone and cause erroneous results.
             # Pendulum uses UTC by default, but we are being explicit here
-            time0 = pendulum.instance(num2date(ds.variables[timevar][0],
+            time0 = pendulum.instance(num2pydate(ds.variables[timevar][0],
                                       ds.variables[timevar].units), 'UTC')
-            time1 = pendulum.instance(num2date(ds.variables[timevar][-1],
+            time1 = pendulum.instance(num2pydate(ds.variables[timevar][-1],
                                       ds.variables[timevar].units), 'UTC')
         except:
             return Result(BaseCheck.MEDIUM,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cftime>=1.1.0
 OWSLib>=0.8.3
 lxml>=3.2.1
 cf-units>=2


### PR DESCRIPTION
Since cftime release 1.1.0, num2date returns instances of cftime.Datetime.
In order to return datetime objects, use the convenience function
cftime.num2pydate.