### PR TITLE
Improve ioos_ingest check

### DIFF
--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -550,7 +550,7 @@ class IOOS1_2Check(IOOSNCCheck):
         If a dataset contains the global attribute ioos_ingest,
         its value must be "false". All datasets are assumed to be
         ingested except those with this flag. If the dataset should
-        be ingested, no flag should be present.
+        be ingested, no flag (or "true") should be present.
 
         Parameters
         ----------
@@ -565,12 +565,9 @@ class IOOS1_2Check(IOOSNCCheck):
         m = ("To disallow harvest of this dataset to IOOS national products, "
              "global attribute \"ioos_ingest\" must be a string with value \"false\"")
         igst = getattr(ds, "ioos_ingest", None)
-        if igst is not None: # if not supplied, return default pass
-            if isinstance(igst, str):
-                if igst.lower() not in ("true", "false"):
-                    r = False
-            else:
-                r = False
+        if (isinstance(igst, str) and igst.lower() not in ("true", "false")) or (
+            not isinstance(igst, str) and igst is not None):
+            r = False
 
         return Result(BaseCheck.MEDIUM, r, "ioos_ingest", [m])
 

--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -565,8 +565,11 @@ class IOOS1_2Check(IOOSNCCheck):
         m = ("To disallow harvest of this dataset to IOOS national products, "
              "global attribute \"ioos_ingest\" must be a string with value \"false\"")
         igst = getattr(ds, "ioos_ingest", None)
-        if igst is not None:
-            if igst not in ("true", "false"):
+        if igst is not None: # if not supplied, return default pass
+            if isinstance(igst, str):
+                if igst.lower() not in ("true", "false"):
+                    r = False
+            else:
                 r = False
 
         return Result(BaseCheck.MEDIUM, r, "ioos_ingest", [m])

--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -464,7 +464,8 @@ class IOOS1_2Check(IOOSNCCheck):
             #'creator_type',
             'institution',
             'instrument',
-            'ioos_ingest',
+            # checked in check_ioos_ingest
+            #'ioos_ingest',
             'keywords',
             'platform_id',
             'publisher_address',
@@ -558,10 +559,11 @@ class IOOS1_2Check(IOOSNCCheck):
         """
 
         r = True
-        m = "Global attribute \"ioos_ingest\" must be a string with value \"false\""
+        m = ("To disallow harvest of this dataset to IOOS national products, "
+             "global attribute \"ioos_ingest\" must be a string with value \"false\"")
         igst = getattr(ds, "ioos_ingest", None)
         if igst is not None:
-            if igst != "false":
+            if igst not in ("true", "false"):
                 r = False
 
         return Result(BaseCheck.MEDIUM, r, "ioos_ingest", [m])

--- a/compliance_checker/tests/test_ioos_profile.py
+++ b/compliance_checker/tests/test_ioos_profile.py
@@ -707,10 +707,14 @@ class TestIOOS1_2(BaseTestCase):
         ds.setncattr("ioos_ingest", "false")
         self.assertTrue(self.ioos.check_ioos_ingest(ds).value)
 
-        # value anything but false
+        # value true
         ds.setncattr("ioos_ingest", "true")
-        self.assertFalse(self.ioos.check_ioos_ingest(ds).value)
+        self.assertTrue(self.ioos.check_ioos_ingest(ds).value)
+
+        # anything else should fail
         ds.setncattr("ioos_ingest", 0)
+        self.assertFalse(self.ioos.check_ioos_ingest(ds).value)
+        ds.setncattr("ioos_ingest", "True")
         self.assertFalse(self.ioos.check_ioos_ingest(ds).value)
         ds.setncattr("ioos_ingest", "False")
         self.assertFalse(self.ioos.check_ioos_ingest(ds).value)

--- a/compliance_checker/tests/test_ioos_profile.py
+++ b/compliance_checker/tests/test_ioos_profile.py
@@ -763,10 +763,14 @@ class TestIOOS1_2(BaseTestCase):
         ds.setncattr("ioos_ingest", "true")
         self.assertTrue(self.ioos.check_ioos_ingest(ds).value)
 
-        # anything else should fail
-        ds.setncattr("ioos_ingest", 0)
-        self.assertFalse(self.ioos.check_ioos_ingest(ds).value)
+        # case insensitive
         ds.setncattr("ioos_ingest", "True")
-        self.assertFalse(self.ioos.check_ioos_ingest(ds).value)
+        self.assertTrue(self.ioos.check_ioos_ingest(ds).value)
         ds.setncattr("ioos_ingest", "False")
+        self.assertTrue(self.ioos.check_ioos_ingest(ds).value)
+
+        # anything else fails
+        ds.setncattr("ioos_ingest", "badval")
+        self.assertFalse(self.ioos.check_ioos_ingest(ds).value)
+        ds.setncattr("ioos_ingest", 0)
         self.assertFalse(self.ioos.check_ioos_ingest(ds).value)


### PR DESCRIPTION
Any value supplied other than "true" or "false" should fail;
add improved error message for clarity.

Now, no more "ioos_ingest" message when testing on https://pae-paha.pacioos.hawaii.edu/erddap/tabledap/WQB-04.html:

```
$ dalton@ubuntu:~/compliance-checker$ python cchecker.py -t ioos:1.2 WQB-04.ncCF | grep "ioos_ingest"
Running Compliance Checker on the datasets from: ['WQB-04.ncCF']
```

```