### PR TITLE
Add check to examine flag_values and flag_meanings

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -1955,7 +1955,7 @@ class CF1_6Check(CFNCCheck):
         '''
         variable = ds.variables[name]
 
-        flag_values = variable.flag_values
+        flag_values = getattr(variable, "flag_values", None)
         flag_meanings = getattr(variable, 'flag_meanings', None)
         valid_values = TestCtx(BaseCheck.HIGH, self.section_titles['3.5'])
 

--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -1081,6 +1081,49 @@ class IOOS1_2Check(IOOSNCCheck):
 
         return results
 
+    def check_qartod_variables_flags(self, ds):
+        """
+        https://github.com/ioos/ioos-metadata/pull/16/commits/c1833adce183d67e0f05edaa0b52c34de431214f
+
+        Check that all QARTOD variables have flag_meanings and flag_values attributes.
+        Use delegation to methods in the CF module.
+
+        Parameters
+        ----------
+        ds (netCDF4.Dataset): open dataset
+
+        Returns
+        -------
+        list of Result objects
+        """
+
+        results = []
+        # get qartod variables
+        for v in ds.get_variables_by_attributes(standard_name=lambda x: x in self._qartod_std_names):
+
+            missing_msg = "flag_{} not present on {}"
+
+            # check if each has flag_values, flag_meanings
+            # need isinstance() as can't compare truth value of array
+            if getattr(v, "flag_values", None) is None:
+                results.append(Result(BaseCheck.MEDIUM, False, "qartod_variables flags", missing_msg.format("values", v.name)))
+
+            else: # if exist, test
+                results.append(self.cf1_7._check_flag_values(ds, v.name))
+
+            if getattr(v, "flag_meanings", None) is None:
+                results.append(Result(BaseCheck.MEDIUM, False, "qartod_variables flags", missing_msg.format("meanings", v.name)))
+
+            else: # if exist, test
+                results.append(self.cf1_7._check_flag_meanings(ds, v.name))
+
+        # Ensure message name is "qartod_variables flags"
+        # NOTE this is a bit of a hack to shove into CF results
+        for r in results:
+            r.name = "qartod_variables flags"
+
+        return results
+
     def check_qartod_variables_references(self, ds):
         """
         For any variables that are deemed QARTOD variables, check that they

--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -1083,7 +1083,7 @@ class IOOS1_2Check(IOOSNCCheck):
 
     def check_qartod_variables_flags(self, ds):
         """
-        https://github.com/ioos/ioos-metadata/pull/16/commits/c1833adce183d67e0f05edaa0b52c34de431214f
+        https://ioos.github.io/ioos-metadata/ioos-metadata-profile-v1-2.html#quality-controlqartod
 
         Check that all QARTOD variables have flag_meanings and flag_values attributes.
         Use delegation to methods in the CF module.


### PR DESCRIPTION
All QARTOD variables should have flag_meanings and flag_values
attributes. Add checks to look for their existence and test they
meet the requirements put forth in the CF specifications.

New output looks like so (for the [org_cormp_sun2.nc](http://testing.erddap.axds.co/erddap/tabledap/org_cormp_sun2.nc) dataset):

```
qartod_variables flags
* air_temperature_qc_agg's flag_values must be an array of values not <class 'str'>
* air_pressure_qc_agg's flag_values must be an array of values not <class 'str'>
* relative_humidity_qc_agg's flag_values must be an array of values not <class 'str'>
* sea_water_velocity_to_direction_qc_agg's flag_values must be an array of values not <class 'str'>
* sea_water_speed_qc_agg's flag_values must be an array of values not <class 'str'>
* sea_water_practical_salinity_qc_agg's flag_values must be an array of values not <class 'str'>
* sea_water_temperature_qc_agg's flag_values must be an array of values not <class 'str'>
* sea_surface_dominant_wave_period_qc_agg's flag_values must be an array of values not <class 'str'>
* sea_surface_wave_significant_height_qc_agg's flag_values must be an array of values not <class 'str'>
* wind_speed_of_gust_qc_agg's flag_values must be an array of values not <class 'str'>
* wind_speed_qc_agg's flag_values must be an array of values not <class 'str'>
* wind_from_direction_qc_agg's flag_values must be an array of values not <class 'str'>
```

Addresses #764 