### PR TITLE
Adds ability to fetch latest CF standard name table

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,9 @@ optional arguments:
   -l, --list-tests      List the available tests
   -d DOWNLOAD_STANDARD_NAMES, --download-standard-names DOWNLOAD_STANDARD_NAMES
                         Specify a version of the cf standard name table to
-                        download as packaged version
+                        download as packaged version. Either specify a version
+                        number (e.g. "72") to fetch a specific version or
+                        "latest" to get the latest CF standard name table.
 ```
 
 ## Examples

--- a/cchecker.py
+++ b/cchecker.py
@@ -128,7 +128,10 @@ def main():
 
     parser.add_argument('-d', '--download-standard-names',
                         help=("Specify a version of the cf standard name table"
-                              " to download as packaged version"))
+                              " to download as packaged version. Either specify"
+                              " a version number (e.g. \"72\") to fetch a "
+                              "specific version or \"latest\" to get the "
+                              "latest CF standard name table."))
 
     # Add command line args from generator plugins
     check_suite.add_plugin_args(parser)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ regex>=2017.07.28
 pendulum>=1.2.4
 pyproj>=2.2.1
 validators>=0.14.2           
+beautifulsoup4>=4.8.1


### PR DESCRIPTION
Adds an option to the `-d` flag to download the latest CF standard name
table without needing to explicitly specify a version.  This is expected
to be useful in cases with non-interactive runs of the compliance
checker (e.g. scheduled checker runs) where an up to date standard name
table is desired.