### PR TITLE
add pre-commit hooks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,20 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+    - name: set PY
+      run: echo "::set-env name=PY::$(python --version --version | sha256sum | cut -d' ' -f1)"
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+    - uses: pre-commit/action@v1.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.mypy_cache/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+known_third_party = cf_units,cftime,httpretty,isodate,lxml,netCDF4,numpy,owslib,pendulum,pkg_resources,pygeoif,pyproj,pytest,regex,requests,setuptools,validators

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   hooks:
   - id: isort
     additional_dependencies: [toml]
-    args: [--project=erddapy, --multi-line=3, --lines-after-imports=2, --lines-between-types=1, --trailing-comma, --force-grid-wrap=0, --use-parentheses, --line-width=88]
+    args: [--project=compliance_checker, --multi-line=3, --lines-after-imports=2, --lines-between-types=1, --trailing-comma, --force-grid-wrap=0, --use-parentheses, --line-width=88]
 
 - repo: https://github.com/asottile/seed-isort-config
   rev: v1.9.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,39 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.5.0
+  hooks:
+    - id: trailing-whitespace
+    - id: check-ast
+    - id: debug-statements
+
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.7.9
+  hooks:
+    - id: flake8
+      exclude: docs/source/conf.py
+      args: [--max-line-length=105]
+
+- repo: https://github.com/pre-commit/mirrors-isort
+  rev: v4.3.21
+  hooks:
+  - id: isort
+    additional_dependencies: [toml]
+    args: [--project=erddapy, --multi-line=3, --lines-after-imports=2, --lines-between-types=1, --trailing-comma, --force-grid-wrap=0, --use-parentheses, --line-width=88]
+
+- repo: https://github.com/asottile/seed-isort-config
+  rev: v1.9.4
+  hooks:
+    - id: seed-isort-config
+
+- repo: https://github.com/psf/black
+  rev: 19.10b0
+  hooks:
+  - id: black
+    language_version: python3
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.761
+  hooks:
+  - id: mypy
+    exclude: docs/source/conf.py
+    args: [--ignore-missing-imports]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,5 @@
 flake8
-pytest>=2.9.0
 httpretty
+mypy
+pre-commit
+pytest>=2.9.0


### PR DESCRIPTION
Once merge this will add a GitHub action that runs the pre-commit hooks configuration.

The checks are:

https://github.com/pre-commit/pre-commit-hooks
- trailing space
- check-ast
- debug-statements

https://github.com/pre-commit/mirrors-isort
https://github.com/asottile/seed-isort-config
- isort with third party from seed-isort

https://github.com/psf/black
- black

https://github.com/pre-commit/mirrors-mypy
- mypy

I use all of those in my projects but we may not need of them at once here.

Fixing all code style checks cab be done incrementally or in a single massive commit. While the latter is harder I'd rather do it once and then we just need to keep the code tidy. Also, a massive commit makes git-blame easier thanks to git >=2.23 `--ignore-revs`', see https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt.