### PR TITLE
Enable ncCF format requests to TableDAP

### DIFF
--- a/compliance_checker/protocols/erddap.py
+++ b/compliance_checker/protocols/erddap.py
@@ -1,0 +1,42 @@
+import io
+import urllib.request
+import compliance_checker.protocols.opendap as opendap
+
+def is_tabledap(url):
+    """
+    Identify a dataset as an ERDDAP TableDAP dataset.
+
+    Parameters
+    ----------
+    url (str) : URL to dataset
+
+    Returns
+    -------
+    bool
+    """
+
+    if "tabledap" in url:
+        return True
+    return False
+
+def get_tabledap_bytes(url, ftype):
+    """
+    ERDDAP TableDAP returns an OPeNDAP "sequence" response by default
+    when no file extensions are provided. If a user wishes to get a dataset
+    from an ERDDAP TableDAP URL, append the desired file extension and return
+    a byte buffer object containing the data.
+
+    Parameters
+    ----------
+    url (str)   : URL to TableDAP dataset
+    ftype (str) : file format extension
+
+    Return
+    ------
+    io.BytesIO buffer object
+    """
+
+    vstr = opendap.create_DAP_variable_str(url) # variable str from DDS
+    _url = f'{".".join([url, ftype])}?{vstr}'
+    with urllib.request.urlopen(_url) as resp:
+        return io.BytesIO(resp.read())

--- a/compliance_checker/protocols/opendap.py
+++ b/compliance_checker/protocols/opendap.py
@@ -4,8 +4,45 @@ compliance_checker/protocols/opendap.py
 
 Functions to assist in determining if the URL is an OPeNDAP endpoint
 '''
+import io
 import requests
+import urllib.parse
+import urllib.request
 
+def create_DAP_variable_str(url):
+    """
+    Create a URL-encoded string of variables for a given DAP dataset.
+    Works on OPeNDAP datasets.
+
+    Parameters
+    ----------
+    url (str): endpoint to *DAP dataset
+
+    Returns
+    -------
+    str
+    """
+
+    # get dds
+    with urllib.request.urlopen(f"{url}.dds") as resp:
+        strb = io.StringIO(resp.read().decode())
+
+    strb.seek(8) # remove "Dataset "
+    x = strb.read()
+    strb.close()
+
+    # remove beginning and ending braces, split on newlines
+    lst = list(filter(lambda x: "{" not in x and "}" not in x, x.split("\n")))
+
+    # remove all the extra space used in the DDS string
+    lst = list(filter(None, map(lambda x: x.strip(" "), lst)))
+
+    # now need to split from type, grab only the variable and remove ;
+    lst = list(map(lambda x: x.split(" ")[-1].strip(";"), lst))
+
+    # encode as proper URL characters
+    varstr = urllib.parse.quote(",".join(lst))
+    return varstr
 
 def is_opendap(url):
     '''

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -15,7 +15,7 @@ from compliance_checker.base import fix_return_value, Result, GenericFile
 from compliance_checker.cf.cf import CFBaseCheck
 from owslib.sos import SensorObservationService
 from owslib.swe.sensor.sml import SensorML
-from compliance_checker.protocols import opendap, netcdf, cdl
+from compliance_checker.protocols import opendap, netcdf, cdl, erddap
 from compliance_checker.base import BaseCheck
 from compliance_checker import MemoizedDataset
 from collections import defaultdict
@@ -723,7 +723,13 @@ class CheckSuite(object):
         :param str ds_str: URL to the remote resource
         '''
 
-        if opendap.is_opendap(ds_str):
+        if erddap.is_tabledap(ds_str):
+            return Dataset(
+                ds_str,
+                mode="r",
+                memory=erddap.get_tabledap_bytes(ds_str, "ncCF").getbuffer()
+            )
+        elif opendap.is_opendap(ds_str):
             return Dataset(ds_str)
         else:
             # Check if the HTTP response is XML, if it is, it's likely SOS so


### PR DESCRIPTION
__ERDDAP TableDAP Requests__

When making a request to `TableDAP`, ensure the `.ncCF` (Contiguous ragged array) format is returned. In order for the data to be returned, the full URl must be generated listing all the variables as the `TableDAP` query. The binary data is fetched from the server, and then instantiated as a `netCDF4.Dataset` representation, allowing proper checking.

Users are only required to supply the base URL to the dataset, e.g.

```
$ compliance-checker -t ioos "http://data.glos.us/erddap/tabledap/glerlwe2"
```

This commit addresses #798.

It should be noted that this approach takes a significant amount of time to fetch the data, far longer than downloading the file and running the checker on a local file.

Unit tests are forthcoming after deliberating on this approach.