### PR TITLE
Process Content-Type header values of application/x-netcdf

### DIFF
--- a/compliance_checker/tests/test_protocols.py
+++ b/compliance_checker/tests/test_protocols.py
@@ -13,6 +13,17 @@ from compliance_checker.suite import CheckSuite
 
 @pytest.mark.integration
 class TestProtocols(TestCase):
+
+    def test_netcdf_content_type(self):
+        """
+        Check that urls with Content-Type header of "application/x-netcdf" can
+        successfully be read into memory for checks.
+        """
+        url = 'https://gliders.ioos.us/erddap/tabledap/amelia-20180501T0000.ncCF?&time%3E=max(time)-1%20hour'
+        cs = CheckSuite()
+        ds = cs.load_dataset(url)
+        assert ds is not None
+
     def test_erddap(self):
         """
         Tests that a connection can be made to ERDDAP's GridDAP


### PR DESCRIPTION
Issues an HTTP HEAD request and handles "Content-Type: application/x-netcdf"
headers by attempting to open a netCDF file in memory.  Opening in
memory will require the netCDF-C library to be compiled with that
feature.