### PR TITLE
Remote NetCDF TableDAP

### DIFF
--- a/compliance_checker/__init__.py
+++ b/compliance_checker/__init__.py
@@ -4,6 +4,9 @@ from netCDF4 import Dataset
 
 from ._version import get_versions
 
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
+from typing import BinaryIO, Generator
 
 __version__ = get_versions()["version"]
 del get_versions
@@ -20,3 +23,30 @@ class MemoizedDataset(Dataset):
     @lru_cache(128)
     def get_variables_by_attributes(self, **kwargs):
         return super(MemoizedDataset, self).get_variables_by_attributes(**kwargs)
+
+@contextmanager
+def tempnc(data: BinaryIO) -> Generator[str, None, None]:
+    """
+    Create a temporary in-memory NetCDF file using a NamedTemporaryFile.
+    Close the file automatically after scope is exited.
+
+    Type aliasing and tempfile creation credit to @ocefpaf
+    https://github.com/ioos/compliance-checker/pull/799#discussion_r411420587
+
+    Parameters
+    ----------
+    data (bytes): raw bytes to store in the NamedTemporaryFile
+
+    Returns
+    -------
+    context-managed generator
+    """
+    tmp = None
+    try:
+        tmp = NamedTemporaryFile(suffix=".nc", prefix="compliance-checker_")
+        tmp.write(data)
+        tmp.flush()
+        yield tmp.name
+    finally:
+        if tmp is not None:
+            tmp.close()

--- a/compliance_checker/protocols/erddap.py
+++ b/compliance_checker/protocols/erddap.py
@@ -1,7 +1,3 @@
-import io
-import urllib.request
-import compliance_checker.protocols.opendap as opendap
-
 def is_tabledap(url):
     """
     Identify a dataset as an ERDDAP TableDAP dataset.
@@ -15,28 +11,4 @@ def is_tabledap(url):
     bool
     """
 
-    if "tabledap" in url:
-        return True
-    return False
-
-def get_tabledap_bytes(url, ftype):
-    """
-    ERDDAP TableDAP returns an OPeNDAP "sequence" response by default
-    when no file extensions are provided. If a user wishes to get a dataset
-    from an ERDDAP TableDAP URL, append the desired file extension and return
-    a byte buffer object containing the data.
-
-    Parameters
-    ----------
-    url (str)   : URL to TableDAP dataset
-    ftype (str) : file format extension
-
-    Return
-    ------
-    io.BytesIO buffer object
-    """
-
-    vstr = opendap.create_DAP_variable_str(url) # variable str from DDS
-    _url = f'{".".join([url, ftype])}?{vstr}'
-    with urllib.request.urlopen(_url, timeout=120) as resp:
-        return io.BytesIO(resp.read())
+    return "tabledap" in url

--- a/compliance_checker/protocols/erddap.py
+++ b/compliance_checker/protocols/erddap.py
@@ -1,0 +1,42 @@
+import io
+import urllib.request
+import compliance_checker.protocols.opendap as opendap
+
+def is_tabledap(url):
+    """
+    Identify a dataset as an ERDDAP TableDAP dataset.
+
+    Parameters
+    ----------
+    url (str) : URL to dataset
+
+    Returns
+    -------
+    bool
+    """
+
+    if "tabledap" in url:
+        return True
+    return False
+
+def get_tabledap_bytes(url, ftype):
+    """
+    ERDDAP TableDAP returns an OPeNDAP "sequence" response by default
+    when no file extensions are provided. If a user wishes to get a dataset
+    from an ERDDAP TableDAP URL, append the desired file extension and return
+    a byte buffer object containing the data.
+
+    Parameters
+    ----------
+    url (str)   : URL to TableDAP dataset
+    ftype (str) : file format extension
+
+    Return
+    ------
+    io.BytesIO buffer object
+    """
+
+    vstr = opendap.create_DAP_variable_str(url) # variable str from DDS
+    _url = f'{".".join([url, ftype])}?{vstr}'
+    with urllib.request.urlopen(_url, timeout=120) as resp:
+        return io.BytesIO(resp.read())

--- a/compliance_checker/protocols/opendap.py
+++ b/compliance_checker/protocols/opendap.py
@@ -4,7 +4,6 @@ compliance_checker/protocols/opendap.py
 
 Functions to assist in determining if the URL is an OPeNDAP endpoint
 """
-import io
 import requests
 import urllib.parse
 import urllib.request
@@ -25,23 +24,19 @@ def create_DAP_variable_str(url):
 
     # get dds
     with urllib.request.urlopen(f"{url}.dds") as resp:
-        strb = io.StringIO(resp.read().decode())
-
-    strb.seek(8) # remove "Dataset "
-    x = strb.read()
-    strb.close()
+        _str = resp.read().decode()[8:]
 
     # remove beginning and ending braces, split on newlines
-    lst = list(filter(lambda x: "{" not in x and "}" not in x, x.split("\n")))
+    no_braces_newlines = list(filter(lambda x: "{" not in x and "}" not in x, _str.split("\n")))
 
     # remove all the extra space used in the DDS string
-    lst = list(filter(None, map(lambda x: x.strip(" "), lst)))
+    no_spaces = list(filter(None, map(lambda x: x.strip(" "), no_braces_newlines)))
 
     # now need to split from type, grab only the variable and remove ;
-    lst = list(map(lambda x: x.split(" ")[-1].strip(";"), lst))
+    vars_only = list(map(lambda x: x.split(" ")[-1].strip(";"), no_spaces))
 
     # encode as proper URL characters
-    varstr = urllib.parse.quote(",".join(lst))
+    varstr = urllib.parse.quote(",".join(vars_only))
     return varstr
 
 def is_opendap(url):

--- a/compliance_checker/protocols/opendap.py
+++ b/compliance_checker/protocols/opendap.py
@@ -4,8 +4,45 @@ compliance_checker/protocols/opendap.py
 
 Functions to assist in determining if the URL is an OPeNDAP endpoint
 """
+import io
 import requests
+import urllib.parse
+import urllib.request
 
+def create_DAP_variable_str(url):
+    """
+    Create a URL-encoded string of variables for a given DAP dataset.
+    Works on OPeNDAP datasets.
+
+    Parameters
+    ----------
+    url (str): endpoint to *DAP dataset
+
+    Returns
+    -------
+    str
+    """
+
+    # get dds
+    with urllib.request.urlopen(f"{url}.dds") as resp:
+        strb = io.StringIO(resp.read().decode())
+
+    strb.seek(8) # remove "Dataset "
+    x = strb.read()
+    strb.close()
+
+    # remove beginning and ending braces, split on newlines
+    lst = list(filter(lambda x: "{" not in x and "}" not in x, x.split("\n")))
+
+    # remove all the extra space used in the DDS string
+    lst = list(filter(None, map(lambda x: x.strip(" "), lst)))
+
+    # now need to split from type, grab only the variable and remove ;
+    lst = list(map(lambda x: x.split(" ")[-1].strip(";"), lst))
+
+    # encode as proper URL characters
+    varstr = urllib.parse.quote(",".join(lst))
+    return varstr
 
 def is_opendap(url):
     """

--- a/compliance_checker/tests/test_protocols.py
+++ b/compliance_checker/tests/test_protocols.py
@@ -13,6 +13,17 @@ from compliance_checker.suite import CheckSuite
 
 @pytest.mark.integration
 class TestProtocols(TestCase):
+
+    def test_netcdf_content_type(self):
+        """
+        Check that urls with Content-Type header of "application/x-netcdf" can
+        successfully be read into memory for checks.
+        """
+        url = 'https://gliders.ioos.us/erddap/tabledap/amelia-20180501T0000.ncCF?&time%3E=max(time)-1%20hour'
+        cs = CheckSuite()
+        ds = cs.load_dataset(url)
+        assert ds is not None
+
     def test_erddap(self):
         """
         Tests that a connection can be made to ERDDAP's GridDAP


### PR DESCRIPTION
Take elements of #799 and #800 to fetch remote NetCDF resources and uses this capability to fetch ERDDAP TableDAP datasets with the .ncCF extension.