### PR TITLE
Tabledap check content type

### DIFF
--- a/compliance_checker/protocols/opendap.py
+++ b/compliance_checker/protocols/opendap.py
@@ -23,7 +23,7 @@ def create_DAP_variable_str(url):
     """
 
     # get dds
-    with urllib.request.urlopen(f"{url}.dds") as resp:
+    with urllib.request.urlopen("{}.dds".format(url)) as resp:
         _str = resp.read().decode()[8:]
 
     # remove beginning and ending braces, split on newlines


### PR DESCRIPTION
Checks if TableDAP endpoint has `application/x-netcdf` Content-Type header prior to rewriting URL.  This fixes an issue where specifying a URL such as https://gliders.ioos.us/erddap/tabledap/amelia-20180501T0000.nc?&time%3E=max(time)-3%20hours  would attempt to rewrite and would lead to a dataset that didn't exist.