### PR TITLE
Removes 2x requirements file scan

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ def readme():
 
 
 def pip_requirements(fname="requirements.txt"):
+    reqs = []
     with open(fname, "r") as f:
         for line in f:
             line = line.strip()
@@ -19,8 +20,6 @@ def pip_requirements(fname="requirements.txt"):
             reqs.append(line)
     return reqs
 
-
-reqs = [line.strip() for line in open("requirements.txt")]
 
 setup(
     name="compliance-checker",


### PR DESCRIPTION
It was observed that the setup script reads the requirements file twice.
This commit removes a line that may have been left over from a previous
way of defining the project's requirements, and shifts the
responsibility of reading the project's dependencies to the
`pip_requirements` function.