### PR TITLE
Updates CLI help text of supported dataset types

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ usage: cchecker.py [-h] [--test TEST] [--criteria [{lenient,normal,strict}]]
 
 positional arguments:
   dataset_location      Defines the location of the dataset to be checked.
+                        The location can be a local netCDF file, a remote
+                        OPeNDAP endpoint, a remote netCDF file which returns
+                        content-type header of 'application/x-netcdf', or an
+                        ERDDAP TableDAP endpoint. Note that the ERDDAP TableDAP
+                        endpoint will currently attempt to fetch the entire
+                        TableDAP dataset.
+
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/cchecker.py
+++ b/cchecker.py
@@ -180,8 +180,12 @@ def main():
     parser.add_argument(
         "dataset_location",
         nargs="*",
-        help="Defines the location of the dataset to be checked.",
-    )
+        help=("Defines the location of the dataset to be checked. The location "
+              "can be a local netCDF file, a remote OPeNDAP endpoint, a remote "
+              "netCDF file which returns content-type header of "
+              "'application/x-netcdf', or an ERDDAP TableDAP endpoint. "
+              "Note that the ERDDAP TableDAP endpoint will currently attempt "
+              "to fetch the entire TableDAP dataset."))
 
     parser.add_argument(
         "-l", "--list-tests", action="store_true", help="List the available tests"


### PR DESCRIPTION
Updates help text to reflect added support for remote netCDF
(non-OPeNDAP) and ERDDAP TableDAP endpoints.