### PR TITLE
use file path instead of contents as name

### DIFF
--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -765,7 +765,8 @@ class CheckSuite(object):
             response = requests.get(ds_str, allow_redirects=True,
                                     timeout=60)
             try:
-                return MemoizedDataset(response.content, memory=response.content)
+                return MemoizedDataset(urlparse(response.url).path,
+                                       memory=response.content)
             except OSError as e:
                 # handle case when netCDF C libs weren't compiled with
                 # in-memory support by using tempfile


### PR DESCRIPTION
I understand that `compliance-checker` does not use that name for anything but the method is public and using the file contents as the name is a bit awkward. Also, the file contents can be a huge string depending on the dataset, maybe this can improve performance a little bit too.