### PR TITLE
ignore zero-dim variables when determining featureType; part of #719

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -4227,7 +4227,11 @@ class CF1_6Check(CFNCCheck):
         all_the_same = TestCtx(BaseCheck.HIGH, self.section_titles["9.1"])
         feature_types_found = defaultdict(list)
         # iterate all geophysical variables with at least one dimension
-        for name in [name for name in self._find_geophysical_vars(ds) if len(ds.variables[name].shape) > 0]:
+        for name in [
+            name
+            for name in self._find_geophysical_vars(ds)
+            if len(ds.variables[name].shape) > 0
+        ]:
             feature = cfutil.guess_feature_type(ds, name)
             # If we can't figure out the feature type, penalize. Originally,
             # it was not penalized. However, this led to the issue that the

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -4227,11 +4227,11 @@ class CF1_6Check(CFNCCheck):
         all_the_same = TestCtx(BaseCheck.HIGH, self.section_titles["9.1"])
         feature_types_found = defaultdict(list)
         # iterate all geophysical variables with at least one dimension
-        for name in [
+        for name in (
             name
             for name in self._find_geophysical_vars(ds)
             if len(ds.variables[name].shape) > 0
-        ]:
+        ):
             feature = cfutil.guess_feature_type(ds, name)
             # If we can't figure out the feature type, penalize. Originally,
             # it was not penalized. However, this led to the issue that the

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -4226,7 +4226,8 @@ class CF1_6Check(CFNCCheck):
         """
         all_the_same = TestCtx(BaseCheck.HIGH, self.section_titles["9.1"])
         feature_types_found = defaultdict(list)
-        for name in self._find_geophysical_vars(ds):
+        # iterate all geophysical variables with at least one dimension
+        for name in [name for name in self._find_geophysical_vars(ds) if len(ds.variables[name].shape) > 0]:
             feature = cfutil.guess_feature_type(ds, name)
             # If we can't figure out the feature type, penalize. Originally,
             # it was not penalized. However, this led to the issue that the


### PR DESCRIPTION
Zero-dimensional data variables cannot have a feature type -- but they might be geophysical variables. Up till now, all variables returned by `self._find_geophysical_vars(ds)` were iterated. This lead to some issues. Some zero-dimensional variables might be geophysical variables. Therefore, they should be returned by `_find_geophysical_vars`. However, they should not be iterated in one for-loop, which throws an error on each not-identifiable feature type (fixes parts of #719 ). 