### PR TITLE
improve warning message when dimension order is bad (CF 2.4)

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -1562,7 +1562,8 @@ class CF1_6Check(CFNCCheck):
                     "".format(
                         name,
                         self._get_pretty_dimension_order(ds, name),
-                        ", ".join(dimension_order)),
+                        ", ".join(dimension_order),
+                    ),
                 )
         return valid_dimension_order.to_result()
 

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -1554,9 +1554,13 @@ class CF1_6Check(CFNCCheck):
                 dimension_order = self._get_dimension_order(ds, name, coord_axis_map)
                 valid_dimension_order.assert_true(
                     self._dims_in_order(dimension_order),
-                    "{}'s dimensions are not in the recommended order "
-                    "T, Z, Y, X. They are {}"
-                    "".format(name, self._get_pretty_dimension_order(ds, name)),
+                    "{}'s spatio-temporal dimensions are not in the "
+                    "recommended order T, Z, Y, X and/or further dimensions "
+                    "are not located left of T, Z, Y, X. The dims are {}. "
+                    "Their guessed types are {} (with U: unknown/other; L: "
+                    "unlimited)."
+                    "".format(name, self._get_pretty_dimension_order(ds, name),
+                        ", ".join(dimension_order)),
                 )
         return valid_dimension_order.to_result()
 

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -1559,7 +1559,9 @@ class CF1_6Check(CFNCCheck):
                     "are not located left of T, Z, Y, X. The dims are {}. "
                     "Their guessed types are {} (with U: unknown/other; L: "
                     "unlimited)."
-                    "".format(name, self._get_pretty_dimension_order(ds, name),
+                    "".format(
+                        name,
+                        self._get_pretty_dimension_order(ds, name),
                         ", ".join(dimension_order)),
                 )
         return valid_dimension_order.to_result()

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -1580,7 +1580,7 @@ class CF1_6Check(CFNCCheck):
                     "{}'s spatio-temporal dimensions are not in the "
                     "recommended order T, Z, Y, X and/or further dimensions "
                     "are not located left of T, Z, Y, X. The dimensions (and "
-                    "their guessed types) are {} (U: other/unknown; L: "
+                    "their guessed types) are {} (with U: other/unknown; L: "
                     "unlimited).".format(
                         name,
                         self._get_pretty_dimension_order_with_type(

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -953,7 +953,7 @@ class CFBaseCheck(BaseCheck):
     def _get_pretty_dimension_order_with_type(self, ds, name, dim_types):
         """
         Returns a comma separated string of the dimensions for a specified
-        variable of format "DIMENSIONS_NAME (DIMENSION_TYPE[, Unlimited])"
+        variable of format "DIMENSIONS_NAME (DIMENSION_TYPE[, unlimited])"
 
         :param netCDF4.Dataset ds: An open netCDF dataset
         :param str name: A string with a valid NetCDF variable name for the
@@ -967,7 +967,7 @@ class CFBaseCheck(BaseCheck):
         for dim, dim_type in zip(ds.variables[name].dimensions, dim_types):
             dim_name = "{} ({}".format(dim, dim_type)
             if ds.dimensions[dim].isunlimited():
-                dim_name += ", Unlimited)"
+                dim_name += ", unlimited)"
             else:
                 dim_name += ")"
             dim_names.append(dim_name)

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -950,6 +950,29 @@ class CFBaseCheck(BaseCheck):
             dim_names.append(dim_name)
         return ", ".join(dim_names)
 
+    def _get_pretty_dimension_order_with_type(self, ds, name, dim_types):
+        """
+        Returns a comma separated string of the dimensions for a specified
+        variable of format "DIMENSIONS_NAME (DIMENSION_TYPE[, Unlimited])"
+
+        :param netCDF4.Dataset ds: An open netCDF dataset
+        :param str name: A string with a valid NetCDF variable name for the
+                         dataset
+        :param list dim_types: A list of strings returned by
+                               _get_dimension_order for the same "name"
+        :rtype: str
+        :return: A comma separated string of the variable's dimensions
+        """
+        dim_names = []
+        for dim, dim_type in zip(ds.variables[name].dimensions, dim_types):
+            dim_name = "{} ({}".format(dim, dim_type)
+            if ds.dimensions[dim].isunlimited():
+                dim_name += ", Unlimited)"
+            else:
+                dim_name += ")"
+            dim_names.append(dim_name)
+        return ", ".join(dim_names)
+
     def _is_station_var(self, var):
         """
         Returns True if the NetCDF variable is associated with a station, False
@@ -1556,13 +1579,13 @@ class CF1_6Check(CFNCCheck):
                     self._dims_in_order(dimension_order),
                     "{}'s spatio-temporal dimensions are not in the "
                     "recommended order T, Z, Y, X and/or further dimensions "
-                    "are not located left of T, Z, Y, X. The dims are {}. "
-                    "Their guessed types are {} (with U: unknown/other; L: "
-                    "unlimited)."
-                    "".format(
+                    "are not located left of T, Z, Y, X. The dimensions (and "
+                    "their guessed types) are {} (U: other/unknown; L: "
+                    "unlimited).".format(
                         name,
-                        self._get_pretty_dimension_order(ds, name),
-                        ", ".join(dimension_order),
+                        self._get_pretty_dimension_order_with_type(
+                            ds, name, dimension_order
+                        ),
                     ),
                 )
         return valid_dimension_order.to_result()

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -307,8 +307,10 @@ class TestCF1_6(BaseTestCase):
         result = self.cf.check_dimension_order(dataset)
         assert result.value == (5, 6)
         assert result.msgs[0] == (
-            u"really_bad's dimensions are not in the recommended order "
-            "T, Z, Y, X. They are latitude, power"
+            u"really_bad's spatio-temporal dimensions are not in the "
+            "recommended order T, Z, Y, X and/or further dimensions are not "
+            "located left of T, Z, Y, X. The dims are latitude, power. Their "
+            "guessed types are Y, U (with U: unknown/other; L: unlimited)."
         )
 
         dataset = self.load_dataset(STATIC_FILES["dimension_order"])

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -309,8 +309,9 @@ class TestCF1_6(BaseTestCase):
         assert result.msgs[0] == (
             u"really_bad's spatio-temporal dimensions are not in the "
             "recommended order T, Z, Y, X and/or further dimensions are not "
-            "located left of T, Z, Y, X. The dims are latitude, power. Their "
-            "guessed types are Y, U (with U: unknown/other; L: unlimited)."
+            "located left of T, Z, Y, X. The dimensions (and their guessed "
+            "types) are latitude (Y), power (U) (with U: other/unknown; L: "
+            "unlimited)."
         )
 
         dataset = self.load_dataset(STATIC_FILES["dimension_order"])


### PR DESCRIPTION
fixed #836 

* update message from `VARIBALE's dimensions are not in the recommended order T, Z, Y, X. They are DIMENSIONs` to `VARIBALE's spatio-temporal dimensions are not in the recommended order T, Z, Y, X and/or further dimensions are not located left of T, Z, Y, X.  The dims are DIMENSIONs. Their guessed types are DIMENSION_TYPES (U: other/unknown; L: unlimited).`.
* updated unit test, which checks this warning message