### PR TITLE
Relax type checking with scale_factor and add_offset variable attributes

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -5297,16 +5297,11 @@ class CF1_7Check(CF1_6Check):
         correct_computed_std_name_ctx = TestCtx(
             BaseCheck.MEDIUM, self.section_titles["4.3"]
         )
-        _comp_std_names = dim_vert_coords_dict[standard_name][1]
-        comp_std_name_attr_val =  getattr(variable, "computed_standard_name",
-                                          None)
-        # having a computed standard name is optional, but if it is present,
-        # it should correspond to the standard_name desired
-        if comp_std_name_attr_val is not None:
-            correct_computed_std_name_ctx.assert_true(
-                comp_std_name_attr_val in _comp_std_names,
-                "§4.3.3 The standard_name of `{}` must map to the correct computed_standard_name, `{}`".format(
-                    vname, sorted(_comp_std_names)
+        _comp_std_name = dim_vert_coords_dict[standard_name][1]
+        correct_computed_std_name_ctx.assert_true(
+            getattr(variable, "computed_standard_name", None) in _comp_std_name,
+            "§4.3.3 The standard_name of `{}` must map to the correct computed_standard_name, `{}`".format(
+                vname, sorted(_comp_std_name)
             ),
         )
         ret_val.append(correct_computed_std_name_ctx.to_result())

--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -5306,7 +5306,7 @@ class CF1_7Check(CF1_6Check):
             correct_computed_std_name_ctx.assert_true(
                 comp_std_name_attr_val in _comp_std_names,
                 "§4.3.3 The standard_name of `{}` must map to the correct computed_standard_name, `{}`".format(
-                    vname, sorted(_comp_std_name)
+                    vname, sorted(_comp_std_names)
             ),
         )
         ret_val.append(correct_computed_std_name_ctx.to_result())


### PR DESCRIPTION
Don't require exact match for `scale_factor` and `add_offset` attributes as compared WRT parent variable.