### PR TITLE
Prevent exception when feature_type attribute missing

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -4433,7 +4433,7 @@ class CF1_6Check(CFNCCheck):
         }
         # Don't bother checking if it's not a legal featureType
         # if the featureType attribute doesn't exist
-        feature_type = getattr(ds, "featureType", None)
+        feature_type = getattr(ds, "featureType", "")
         if (feature_type is not None and
             feature_type.lower() not in feature_list):
             return []


### PR DESCRIPTION
As mentioned in https://github.com/ioos/compliance-checker/pull/875#discussion_r680690974, if the `featureType` global attribute is missing, the CF check suite throws a `'NoneType' object has no attribute 'lower'` exception.

This should prevent that, without affecting any of the logic.