### PR TITLE
Remove unittest dependency for command line tests

### DIFF
--- a/compliance_checker/tests/conftest.py
+++ b/compliance_checker/tests/conftest.py
@@ -99,16 +99,18 @@ def new_nc_file(tmpdir):
     # no need for cleanup, built-in tmpdir fixture will handle it
     return nc
 
+
 @pytest.fixture
 def tmp_txt_file(tmpdir):
     file_path = os.path.join(tmpdir, "output.txt")
     if os.path.exists(file_path):
         raise IOError("File Exists: %s" % file_path)
-    
+
     return file_path
+
 
 @pytest.fixture
 def checksuite_setup():
-    '''For test_cli'''
+    """For test_cli"""
     CheckSuite.checkers.clear()
     CheckSuite.load_all_available_checkers()

--- a/compliance_checker/tests/conftest.py
+++ b/compliance_checker/tests/conftest.py
@@ -47,7 +47,7 @@ def static_files(cdl_stem):
         assert (
             nc_path.exists()
         ), f"ncgen CLI utility failed to produce {nc_path} from {cdl_path}"
-    return nc_path
+    return str(nc_path)
 
 
 # ---------Fixtures-----------
@@ -98,3 +98,17 @@ def new_nc_file(tmpdir):
     nc = Dataset(nc_file_path, "w")
     # no need for cleanup, built-in tmpdir fixture will handle it
     return nc
+
+@pytest.fixture
+def tmp_txt_file(tmpdir):
+    file_path = os.path.join(tmpdir, "output.txt")
+    if os.path.exists(file_path):
+        raise IOError("File Exists: %s" % file_path)
+    
+    return file_path
+
+@pytest.fixture
+def checksuite_setup():
+    '''For test_cli'''
+    CheckSuite.checkers.clear()
+    CheckSuite.load_all_available_checkers()

--- a/compliance_checker/tests/test_cli.py
+++ b/compliance_checker/tests/test_cli.py
@@ -14,7 +14,9 @@ from argparse import Namespace
 import pytest
 
 from compliance_checker.runner import CheckSuite, ComplianceChecker
+
 from .conftest import static_files
+
 
 @pytest.mark.usefixtures("checksuite_setup")
 class TestCLI:
@@ -25,7 +27,7 @@ class TestCLI:
     def shortDescription(self):
         return None
 
-    def test_unicode_acdd_html(self,tmp_txt_file):
+    def test_unicode_acdd_html(self, tmp_txt_file):
         """
         Tests that the checker is capable of producing HTML with unicode characters
         """
@@ -40,7 +42,7 @@ class TestCLI:
 
         assert os.stat(tmp_txt_file).st_size > 0
 
-    def test_unicode_cf_html(self,tmp_txt_file):
+    def test_unicode_cf_html(self, tmp_txt_file):
         """
         Tests that the CF checker can produce HTML output with unicode characters
         """
@@ -55,7 +57,7 @@ class TestCLI:
 
         assert os.stat(tmp_txt_file).st_size > 0
 
-    def test_single_json_output(self,tmp_txt_file):
+    def test_single_json_output(self, tmp_txt_file):
         """
         Tests that a suite can produce JSON output to a file
         """
@@ -106,7 +108,7 @@ class TestCLI:
             sys.stdout = saved
             fake_stdout.close()
 
-    def test_multiple_json_output(self,tmp_txt_file):
+    def test_multiple_json_output(self, tmp_txt_file):
         """
         Tests that a suite can produce JSON output to a file
         """
@@ -170,7 +172,7 @@ class TestCLI:
             sys.stdout = saved
             fake_stdout.close()
 
-    def test_text_output(self,tmp_txt_file):
+    def test_text_output(self, tmp_txt_file):
         """
         Tests that the 'text' output can be redirected to file with arguments
         to the command line
@@ -186,7 +188,7 @@ class TestCLI:
 
         assert os.stat(tmp_txt_file).st_size > 0
 
-    def test_multi_checker_return_value(self,tmp_txt_file):
+    def test_multi_checker_return_value(self, tmp_txt_file):
         """
         Tests that any failure for multiple checkers results in a failure return
         status

--- a/compliance_checker/tests/test_cli.py
+++ b/compliance_checker/tests/test_cli.py
@@ -11,93 +11,66 @@ import sys
 import tempfile
 
 from argparse import Namespace
-from unittest import TestCase
 
 import pytest
 
 from compliance_checker.runner import CheckSuite, ComplianceChecker
-from compliance_checker.tests.resources import STATIC_FILES
+from .conftest import static_files
 
-
-class TestCLI(TestCase):
+@pytest.mark.usefixtures("checksuite_setup")
+class TestCLI:
     """
     Tests various functions and aspects of the command line tool and runner
     """
 
-    def setUp(self):
-        self.fid, self.path = tempfile.mkstemp()
-        # why is the class being written to
-        CheckSuite.checkers.clear()
-        CheckSuite.load_all_available_checkers()
-
-    def tearDown(self):
-        if os.path.isfile(self.path):
-            os.close(self.fid)
-            os.remove(self.path)
-
     def shortDescription(self):
         return None
 
-    # override __str__ and __repr__ behavior to show a copy-pastable nosetest name for ion tests
-    #  ion.module:TestClassName.test_function_name
-    def __repr__(self):
-        name = self.id()
-        name = name.split(".")
-        if name[0] not in ["ion", "pyon"]:
-            return "%s (%s)" % (name[-1], ".".join(name[:-1]))
-        else:
-            return "%s ( %s )" % (
-                name[-1],
-                ".".join(name[:-2]) + ":" + ".".join(name[-2:]),
-            )
-
-    __str__ = __repr__
-
-    def test_unicode_acdd_html(self):
+    def test_unicode_acdd_html(self,tmp_txt_file):
         """
         Tests that the checker is capable of producing HTML with unicode characters
         """
         return_value, errors = ComplianceChecker.run_checker(
-            ds_loc=STATIC_FILES["2dim"],
+            ds_loc=static_files("2dim"),
             verbose=0,
             criteria="strict",
             checker_names=["acdd"],
-            output_filename=self.path,
+            output_filename=tmp_txt_file,
             output_format="html",
         )
 
-        assert os.stat(self.path).st_size > 0
+        assert os.stat(tmp_txt_file).st_size > 0
 
-    def test_unicode_cf_html(self):
+    def test_unicode_cf_html(self,tmp_txt_file):
         """
         Tests that the CF checker can produce HTML output with unicode characters
         """
         return_value, errors = ComplianceChecker.run_checker(
-            ds_loc=STATIC_FILES["2dim"],
+            ds_loc=static_files("2dim"),
             verbose=0,
             criteria="strict",
             checker_names=["cf"],
-            output_filename=self.path,
+            output_filename=tmp_txt_file,
             output_format="html",
         )
 
-        assert os.stat(self.path).st_size > 0
+        assert os.stat(tmp_txt_file).st_size > 0
 
-    def test_single_json_output(self):
+    def test_single_json_output(self,tmp_txt_file):
         """
         Tests that a suite can produce JSON output to a file
         """
         return_value, errors = ComplianceChecker.run_checker(
-            ds_loc=STATIC_FILES["conv_bad"],
+            ds_loc=static_files("conv_bad"),
             verbose=0,
             criteria="strict",
             checker_names=["cf"],
-            output_filename=self.path,
+            output_filename=tmp_txt_file,
             output_format="json",
         )
 
-        assert os.stat(self.path).st_size > 0
-        with open(self.path) as f:
+        assert os.stat(tmp_txt_file).st_size > 0
+        with open(tmp_txt_file) as f:
             r = json.load(f)
             assert "cf" in r
 
@@ -134,21 +107,21 @@ class TestCLI(TestCase):
             sys.stdout = saved
             fake_stdout.close()
 
-    def test_multiple_json_output(self):
+    def test_multiple_json_output(self,tmp_txt_file):
         """
         Tests that a suite can produce JSON output to a file
         """
         return_value, errors = ComplianceChecker.run_checker(
-            ds_loc=STATIC_FILES["conv_bad"],
+            ds_loc=static_files("conv_bad"),
             verbose=0,
             criteria="strict",
             checker_names=["acdd", "cf"],
-            output_filename=self.path,
+            output_filename=tmp_txt_file,
             output_format="json",
         )
 
-        assert os.stat(self.path).st_size > 0
-        with open(self.path) as f:
+        assert os.stat(tmp_txt_file).st_size > 0
+        with open(tmp_txt_file) as f:
             r = json.load(f)
             assert "cf" in r
             assert "acdd" in r
@@ -162,7 +135,7 @@ class TestCLI(TestCase):
             fake_stdout = io.StringIO()
             sys.stdout = fake_stdout
             return_value, errors = ComplianceChecker.run_checker(
-                ds_loc=STATIC_FILES["conv_bad"],
+                ds_loc=static_files("conv_bad"),
                 verbose=0,
                 criteria="strict",
                 checker_names=["acdd", "cf"],
@@ -185,7 +158,7 @@ class TestCLI(TestCase):
             fake_stdout = io.StringIO()
             sys.stdout = fake_stdout
             return_value, errors = ComplianceChecker.run_checker(
-                ds_loc=STATIC_FILES["conv_bad"],
+                ds_loc=static_files("conv_bad"),
                 verbose=0,
                 criteria="strict",
                 checker_names=["cf"],
@@ -198,46 +171,46 @@ class TestCLI(TestCase):
             sys.stdout = saved
             fake_stdout.close()
 
-    def test_text_output(self):
+    def test_text_output(self,tmp_txt_file):
         """
         Tests that the 'text' output can be redirected to file with arguments
         to the command line
         """
         return_value, errors = ComplianceChecker.run_checker(
-            ds_loc=STATIC_FILES["conv_bad"],
+            ds_loc=static_files("conv_bad"),
             verbose=0,
             criteria="strict",
             checker_names=["acdd", "cf"],
-            output_filename=self.path,
+            output_filename=tmp_txt_file,
             output_format="text",
         )
 
-        assert os.stat(self.path).st_size > 0
+        assert os.stat(tmp_txt_file).st_size > 0
 
-    def test_multi_checker_return_value(self):
+    def test_multi_checker_return_value(self,tmp_txt_file):
         """
         Tests that any failure for multiple checkers results in a failure return
         status
         """
         # CF should pass here
         return_value, errors = ComplianceChecker.run_checker(
-            ds_loc=STATIC_FILES["ncei_gold_point_1"],
+            ds_loc=static_files("ncei_gold_point_1"),
             verbose=0,
             criteria="strict",
             checker_names=["cf:1.6"],
-            output_filename=self.path,
+            output_filename=tmp_txt_file,
             output_format="text",
         )
-        self.assertTrue(return_value)
+        assert return_value
 
         # CF should pass, but ACDD will have some errors.  Overall return
         # status should be a failure
         return_value, errors = ComplianceChecker.run_checker(
-            ds_loc=STATIC_FILES["ncei_gold_point_1"],
+            ds_loc=static_files("ncei_gold_point_1"),
             verbose=0,
             criteria="strict",
             checker_names=["acdd", "cf"],
-            output_filename=self.path,
+            output_filename=tmp_txt_file,
             output_format="text",
         )
-        self.assertFalse(return_value)
+        assert not return_value

--- a/compliance_checker/tests/test_cli.py
+++ b/compliance_checker/tests/test_cli.py
@@ -8,7 +8,6 @@ import io
 import json
 import os
 import sys
-import tempfile
 
 from argparse import Namespace
 


### PR DESCRIPTION
This is a pretty incremental change but I figured I should make a separate PR for it rather than mix it with something else. Just updating the test_cli.py tests to use pytest instead of unittest, in the same vein as [PR #880](https://github.com/ioos/compliance-checker/pull/880).