### PR TITLE
Include checks

### DIFF
--- a/cchecker.py
+++ b/cchecker.py
@@ -93,7 +93,9 @@ def main():
         action="store_true",
     )
 
-    parser.add_argument(
+    include_exclude = parser.add_mutually_exclusive_group()
+
+    include_exclude.add_argument(
         "--skip-checks",
         "-s",
         help=dedent(
@@ -110,6 +112,26 @@ def main():
                                     will skip medium and low.  "L" will show
                                     both high and medium priority issues, while
                                     skipping low priority issues.
+                                    """
+        ),
+        action="append",
+    )
+
+    include_exclude.add_argument(
+        "--include-checks",
+        "-i",
+        help=dedent(
+            """
+                                    Specifies tests to include. Can only take the form
+                                    of either `<check_name>` or
+                                    `<check_name>:<skip_level>`.  The first
+                                    form skips any checks matching the name.
+                                    In the second form <skip_level> may be
+                                    specified as "H", "M", or "L".  "H" includes
+                                    only high prioity. "M" will show high and
+                                    medium priority output from the given check
+                                    and will skip low.  "L" will show
+                                    both all issues..
                                     """
         ),
         action="append",
@@ -286,6 +308,7 @@ def main():
             args.verbose,
             args.criteria,
             args.skip_checks,
+            args.include_checks,
             args.output[0],
             args.format or ["text"],
             options=options_dict,
@@ -307,6 +330,7 @@ def main():
                 args.verbose,
                 args.criteria,
                 args.skip_checks,
+                args.include_checks,
                 output,
                 args.format or ["text"],
                 options=options_dict,

--- a/cchecker.py
+++ b/cchecker.py
@@ -111,7 +111,8 @@ def main():
                                     priority output from the given check and
                                     will skip medium and low.  "L" will show
                                     both high and medium priority issues, while
-                                    skipping low priority issues.
+                                    skipping low priority issues.  Cannot be
+                                    used with `-i`/`--include` option.
                                     """
         ),
         action="append",
@@ -122,16 +123,9 @@ def main():
         "-i",
         help=dedent(
             """
-                                    Specifies tests to include. Can only take the form
-                                    of either `<check_name>` or
-                                    `<check_name>:<skip_level>`.  The first
-                                    form skips any checks matching the name.
-                                    In the second form <skip_level> may be
-                                    specified as "H", "M", or "L".  "H" includes
-                                    only high prioity. "M" will show high and
-                                    medium priority output from the given check
-                                    and will skip low.  "L" will show
-                                    both all issues..
+                                    Specifies checks to include. Can only take the form
+                                    of `<check_name>`.  Cannot be specified along with
+                                    `-s`/`skip_checks`.
                                     """
         ),
         action="append",

--- a/compliance_checker/runner.py
+++ b/compliance_checker/runner.py
@@ -40,6 +40,7 @@ class ComplianceChecker(object):
         verbose,
         criteria,
         skip_checks=None,
+        include_checks=None,
         output_filename="-",
         output_format=["text"],
         options=None,
@@ -53,6 +54,7 @@ class ComplianceChecker(object):
         @param  criteria        Determines failure (lenient, normal, strict)
         @param  output_filename Path to the file for output
         @param  skip_checks     Names of checks to skip
+        @param  include_checks  Names of checks to include
         @param  output_format   Format of the output(s)
 
         @returns                If the tests failed (based on the criteria)
@@ -74,8 +76,14 @@ class ComplianceChecker(object):
 
         for loc in locs:  # loop through each dataset and run specified checks
             ds = cs.load_dataset(loc)
+            if include_checks:
+                skip_flag = False
+                checks_to_run = include_checks
+            else:
+                skip_flag = True
+                checks_to_run = skip_checks
 
-            score_groups = cs.run(ds, skip_checks, *checker_names)
+            score_groups = cs.run(ds, checks_to_run, skip_flag, *checker_names)
             for group in score_groups.values():
                 all_groups.append(group[0])
             # TODO: consider wrapping in a proper context manager instead
@@ -128,7 +136,8 @@ class ComplianceChecker(object):
                     output_filename = "{}.json".format(
                         os.path.splitext(output_filename)[0]
                     )
-                cls.json_output(cs, score_dict, output_filename, ds_loc, limit, out_fmt)
+                cls.json_output(cs, score_dict, output_filename, ds_loc, limit,
+                                out_fmt)
 
             else:
                 raise TypeError("Invalid format %s" % out_fmt)

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -91,7 +91,8 @@ class CheckSuite(object):
         :type verbose: int
         """
         for checker in sorted(self.checkers.keys()):
-            version = getattr(self.checkers[checker], "_cc_checker_version", "???")
+            version = getattr(self.checkers[checker], "_cc_checker_version",
+                              "???")
             if verbose > 0:
                 print(" - {} (v{})".format(checker, version))
             elif ":" in checker and not checker.endswith(
@@ -196,13 +197,20 @@ class CheckSuite(object):
                 ":".join((spec, latest_version))
             ]
 
-    def _get_checks(self, checkclass, skip_checks, skip_flag=None):
+    def _get_checks(self, checkclass, skip_checks, skip_flag=True):
         """
         Helper method to retrieve check methods from a Checker class.  Excludes
         any checks in `skip_checks`.
 
         The name of the methods in the Checker class should start with "check_"
         for this method to find them.
+        :param checkclass BaseCheck: The checker class being considered
+        :param skip_checks list: A list of strings with the names of the check
+                                 methods to skip or include, depending on the
+                                 value of `skip_flag`.
+        :param skip_flag bool: A boolean parameter to determine whether to
+                               skip over checks specified (True) or only
+                               include the checks specified (False).
         """
         meths = inspect.getmembers(checkclass, inspect.isroutine)
         # return all check methods not among the skipped checks

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1347,7 +1347,7 @@ class TestCF1_6(BaseTestCase):
         dataset = self.load_dataset(STATIC_FILES["ints64"])
         suite = CheckSuite()
         suite.checkers = {"cf": CF1_6Check}
-        suite.run(dataset, "cf")
+        suite.run(dataset, [], True, "cf")
 
     def test_variable_feature_check(self):
 

--- a/compliance_checker/tests/test_cf_integration.py
+++ b/compliance_checker/tests/test_cf_integration.py
@@ -266,7 +266,7 @@ class TestCFIntegration:
         ],  # must be specified to load this param at runtime, instead of at collection
     )
     def test_cf_integration(self, loaded_dataset, expected_messages, cs):
-        check_results = cs.run(loaded_dataset, [], "cf")
+        check_results = cs.run(loaded_dataset, [], True, "cf")
         scored, out_of, messages = self.get_results(check_results, cs)
 
         assert scored < out_of
@@ -291,14 +291,14 @@ class TestCFIntegration:
         indirect=["loaded_dataset"],
     )
     def test_no_incorrect_errors(self, cs, loaded_dataset, wrong_message):
-        check_results = cs.run(loaded_dataset, [], "cf")
+        check_results = cs.run(loaded_dataset, [], True, "cf")
         messages = self.get_results(check_results, cs)[-1]
 
         assert wrong_message not in "".join(messages)
 
     @pytest.mark.parametrize("loaded_dataset", ["fvcom"], indirect=True)
     def test_fvcom(self, cs, loaded_dataset):
-        check_results = cs.run(loaded_dataset, [], "cf")
+        check_results = cs.run(loaded_dataset, [], True, "cf")
         scored, out_of, messages = self.get_results(check_results, cs)
         assert scored < out_of
 

--- a/compliance_checker/tests/test_suite.py
+++ b/compliance_checker/tests/test_suite.py
@@ -87,11 +87,20 @@ class TestSuite(unittest.TestCase):
         # check if netCDF4 file was created
         assert os.path.isfile(static_files["netCDF4"].replace(".cdl", ".nc"))
 
+    def test_include_checks(self):
+        ds = self.cs.load_dataset(static_files["bad_data_type"])
+        score_groups = self.cs.run(ds, ["check_standard_name"], False, "cf:1.7")
+        checks_run = score_groups["cf:1.7"][0]
+        assert len(checks_run) == 1
+        first_check = checks_run[0]
+        assert first_check.name == "§3.3 Standard Name"
+        assert first_check.value[0] < first_check.value[1]
+
     def test_skip_checks(self):
         """Tests that checks are properly skipped when specified"""
         ds = self.cs.load_dataset(static_files["2dim"])
         # exclude title from the check attributes
-        score_groups = self.cs.run(ds, ["check_high"], "acdd")
+        score_groups = self.cs.run(ds, ["check_high"], True, "acdd")
         assert all(
             sg.name not in {"Conventions", "title", "keywords", "summary"}
             for sg in score_groups["acdd"][0]

--- a/compliance_checker/tests/test_suite.py
+++ b/compliance_checker/tests/test_suite.py
@@ -116,6 +116,7 @@ class TestSuite(unittest.TestCase):
                 "check_convention_possibly_var_attrs:M",
                 "check_standard_name:L",
             ],
+            True,
             "cf",
         )
 
@@ -145,7 +146,7 @@ class TestSuite(unittest.TestCase):
         # This is checking for issue #183, where group_func results in
         # IndexError: list index out of range
         ds = self.cs.load_dataset(static_files["bad_data_type"])
-        score_groups = self.cs.run(ds, True, "cf")
+        score_groups = self.cs.run(ds, [], True, "cf")
 
         limit = 2
         for checker, rpair in score_groups.items():
@@ -177,7 +178,7 @@ class TestSuite(unittest.TestCase):
         # Testing whether you can run compliance checker on a .cdl file
         # Load the cdl file
         ds = self.cs.load_dataset(static_files["test_cdl"])
-        vals = self.cs.run(ds, True, "cf")
+        vals = self.cs.run(ds, [], True, "cf")
 
         limit = 2
         for checker, rpair in vals.items():
@@ -193,7 +194,7 @@ class TestSuite(unittest.TestCase):
 
         # Ok now load the nc file that it came from
         ds = self.cs.load_dataset(static_files["test_cdl_nc"])
-        vals = self.cs.run(ds, True, "cf")
+        vals = self.cs.run(ds, [], True, "cf")
 
         limit = 2
         for checker, rpair in vals.items():

--- a/compliance_checker/tests/test_suite.py
+++ b/compliance_checker/tests/test_suite.py
@@ -60,11 +60,11 @@ class TestSuite(unittest.TestCase):
         # BWA: what's the purpose of this test?  Just to see if the suite
         # runs without errors?
         ds = self.cs.load_dataset(static_files["2dim"])
-        self.cs.run(ds, "acdd")
+        self.cs.run(ds, True, "acdd")
 
     def test_unicode_formatting(self):
         ds = self.cs.load_dataset(static_files["bad_region"])
-        score_groups = self.cs.run(ds, "cf")
+        score_groups = self.cs.run(ds, True, "cf")
 
         limit = 2
         for checker, rpair in score_groups.items():
@@ -145,7 +145,7 @@ class TestSuite(unittest.TestCase):
         # This is checking for issue #183, where group_func results in
         # IndexError: list index out of range
         ds = self.cs.load_dataset(static_files["bad_data_type"])
-        score_groups = self.cs.run(ds, "cf")
+        score_groups = self.cs.run(ds, True, "cf")
 
         limit = 2
         for checker, rpair in score_groups.items():
@@ -177,7 +177,7 @@ class TestSuite(unittest.TestCase):
         # Testing whether you can run compliance checker on a .cdl file
         # Load the cdl file
         ds = self.cs.load_dataset(static_files["test_cdl"])
-        vals = self.cs.run(ds, "cf")
+        vals = self.cs.run(ds, True, "cf")
 
         limit = 2
         for checker, rpair in vals.items():
@@ -193,7 +193,7 @@ class TestSuite(unittest.TestCase):
 
         # Ok now load the nc file that it came from
         ds = self.cs.load_dataset(static_files["test_cdl_nc"])
-        vals = self.cs.run(ds, "cf")
+        vals = self.cs.run(ds, True, "cf")
 
         limit = 2
         for checker, rpair in vals.items():
@@ -224,7 +224,7 @@ class TestSuite(unittest.TestCase):
         of potential issues, rather than the weighted score
         """
         ds = self.cs.load_dataset(static_files["bad_region"])
-        score_groups = self.cs.run(ds, [], "cf")
+        score_groups = self.cs.run(ds, [], True, "cf")
         limit = 2
         groups, errors = score_groups["cf"]
         score_list, all_passed, out_of = self.cs.standard_output(

--- a/compliance_checker/tests/test_suite.py
+++ b/compliance_checker/tests/test_suite.py
@@ -64,7 +64,7 @@ class TestSuite(unittest.TestCase):
 
     def test_unicode_formatting(self):
         ds = self.cs.load_dataset(static_files["bad_region"])
-        score_groups = self.cs.run(ds, True, "cf")
+        score_groups = self.cs.run(ds, [], True, "cf")
 
         limit = 2
         for checker, rpair in score_groups.items():

--- a/compliance_checker/tests/test_suite.py
+++ b/compliance_checker/tests/test_suite.py
@@ -60,7 +60,7 @@ class TestSuite(unittest.TestCase):
         # BWA: what's the purpose of this test?  Just to see if the suite
         # runs without errors?
         ds = self.cs.load_dataset(static_files["2dim"])
-        self.cs.run(ds, True, "acdd")
+        self.cs.run(ds, [], True, "acdd")
 
     def test_unicode_formatting(self):
         ds = self.cs.load_dataset(static_files["bad_region"])


### PR DESCRIPTION
Allows checks to be "included"/"allowlisted" so that only a small subset of checks are run, such as a standard name check.

cc @kerfoot:  This functionality will more easily allow for a few checks to be run and a report generated, which will be useful for NCEI archival prerequisites.