### PR TITLE
Remove Python 2.7 warning / contributors image added in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@ for completeness and community standard compliance of local or remote
 file standards. The python module can be used as a command-line tool or as a
 library that can be integrated into other software.
 
-## Python 2.7 Deprecation Notice
-As of release 4.3.0, the __Compliance Checker no longer officially supports Python 2.7__.
-
 A [web-based version](https://data.ioos.us/compliance/index.html) of the Compliance
 Checker was developed to enable a broader audience and improve accessibility for the
 checker. With the web version, providers can simply provide a link or upload their
@@ -436,20 +433,11 @@ compliance-checker -t ncei-trajectory-profile-orthogonal -v ~/data/sample-trajec
 compliance-checker -t ncei-grid -f json -o ~/Documents/sample_grid_report.json ~/Documents/sample_grid_report.nc
 ```
 
-## Contributors
-
-- [Dave Foster](https://github.com/daf) &lt;dave@axiomdatascience.com&gt;
-- [Dan Maher](https://github.com/danieljmaher) &lt;daniel.maher@gdit.com&gt;
-- [Luke Campbell](https://github.com/lukecampbell) &lt;luke@axiomdatascience.com&gt;
-- [Kyle Wilcox](https://github.com/kwilcox) &lt;kyle@axiomdatascience.com&gt;
-- [Ben Adams](https://github.com/benjwadams) &lt;ben.adams@rpsgroup.com&gt;
-- [Bob Fratantonio](https://github.com/bobfrat) &lt;robert.fratantonio@rpsgroup.com&gt;
-- [Dalton Kell](https://github.com/daltonkell) &lt;dalton.kell@rpsgroup.com&gt;
-
-And many more testers!
-
-Portions of the CF checker are based on Michael Decker's work, http://repositories.iek.fz-juelich.de/hg/CFchecker/
-
 ## Disclaimer
 
 The objective of the IOOS Compliance Checker is to check your file against our interpretation of select dataset metadata standards to use as a guideline in generating compliant files. The compliance checker should not be considered the authoritative source on whether your file is 100% "compliant". Instead, we recommend that users use the results as a guide to work towards compliance.
+
+
+## Miscellaneous/Acknowledgements
+
+Portions of the CF checker are based on Michael Decker's work, http://repositories.iek.fz-juelich.de/hg/CFchecker/

--- a/README.md
+++ b/README.md
@@ -440,4 +440,7 @@ The objective of the IOOS Compliance Checker is to check your file against our i
 
 ## Miscellaneous/Acknowledgements
 
+### Contributors
+![GitHub Contributors Image](https://contrib.rocks/image?repo=ioos/compliance-checker)
+
 Portions of the CF checker are based on Michael Decker's work, http://repositories.iek.fz-juelich.de/hg/CFchecker/


### PR DESCRIPTION
Python 2.7 has stopped being supported long time ago, so a notice that it is no longer supported is fairly superfluous.   PyPI/setup.py should indicate supported versions Python versions in any event.

Many other people have made contributions to compliance checker, so it's recommended that this section be removed.