### PR TITLE
Fixes spelling issues reported by `codespell`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
   hooks:
     - id: codespell
       args:
-        - --ignore-words-list=degreeE,degreee,varn,poit,uint,sur,herat
+        - --ignore-words-list=degreeE,degreee,varn,poit,uint,sur,herat,Claus
       exclude: >
           (?x)^(
               .*\.xml|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
   hooks:
     - id: codespell
       args:
-        - --ignore-words-list=degreeE,degreee,varn,poit,uint,sur,herat,Claus
+        - --ignore-words-list=degreee,varn,poit,uint,sur,herat,claus
       exclude: >
           (?x)^(
               .*\.xml|

--- a/compliance_checker/cf/appendix_c.py
+++ b/compliance_checker/cf/appendix_c.py
@@ -1,6 +1,6 @@
 """Appendix C - Standard Name modifiers"""
 
-# Dict of standard name modifiers with values for units.  "u" inidicates to use
+# Dict of standard name modifiers with values for units.  "u" indicates to use
 # the same units as the standard name canonical units, "1" is unitless for
 # observation counts, and None is used for status_flag, which expects units
 # not to be present

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -671,7 +671,7 @@ class CF1_6Check(CFNCCheck):
             units not in deprecated,
             'units for {}, "{}" are deprecated by CF 1.6'.format(variable_name, units),
         )
-        # 4/5) Modifiers, if present, have the approriate units, or none for
+        # 4/5) Modifiers, if present, have the appropriate units, or none for
         #    status_flag
         if standard_name_modifier is not None:
             if standard_name_modifier not in valid_modifiers:

--- a/compliance_checker/cf/cf_1_8.py
+++ b/compliance_checker/cf/cf_1_8.py
@@ -140,7 +140,7 @@ class CF1_8Check(CF1_7Check):
             try:
                 node_coord_var_names = geometry_var.node_coordinates
             except AttributeError as e:
-                geom_valid.messsages.append('Could not find required attribute '
+                geom_valid.messages.append('Could not find required attribute '
                                             '"node_coordinates" in geometry '
                                             f'variable "{geometry_var_name}"')
                 results.append(geom_valid.to_result())

--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -586,7 +586,7 @@ def compare_unit_types(specified, reference):
     Compares two unit strings via UDUnits
 
     :param str specified: The specified unit
-    :param str reference: The reference unit which to compare agains
+    :param str reference: The reference unit which to compare against
 
     """
     msgs = []


### PR DESCRIPTION
Fixes pre-commit spelling errors reported by `codespell`.  Also adds
"Claus" to the list of excluded words since it is referenced in a
biological data citation of an author for a mocked WoRMS entry.