### PR TITLE
update GHAs, clean up yml, use micromamba

### DIFF
--- a/.github/workflows/cc-checker-ugrid-test.yml
+++ b/.github/workflows/cc-checker-ugrid-test.yml
@@ -3,41 +3,40 @@ name: UGRID Plugin Tests
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master,develop,main]
 
 jobs:
   run:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Setup Conda
-      uses: s-weigand/setup-conda@v1
+    - name: Setup Micromamba
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        activate-conda: false
-        conda-channels: conda-forge
+        environment-file: false
 
-    - name: Python ${{ matrix.python-version }}
+    - name: Python
       shell: bash -l {0}
       run: |
-        conda create --name TEST python=${{ matrix.python-version }} python=3 pip --file requirements.txt --file test_requirements.txt --strict-channel-priority
-        source activate TEST
+        micromamba create --name TEST python=3 pip --file requirements.txt --file test_requirements.txt --channel conda-forge
+        micromamba activate TEST
         pip install -e . --no-deps --force-reinstall
 
-    - name: Conda Info
+    - name: micromamba Info
       shell: bash -l {0}
       run: |
-        source activate TEST
-        conda info --all
-        conda list
+        micromamba activate TEST
+        micromamba info --all
+        micromamba list
 
     - name: cc-plugin-glider tests
       shell: bash -l {0}
       run: |
-        source activate TEST
+        micromamba activate TEST
         git clone https://github.com/ioos/cc-checker-ugrid.git
         cd cc-checker-ugrid
         pip install -e . --no-deps --force-reinstall
-        conda install --file requirements.txt --file requirements-dev.txt ;
+        micromamba install --file requirements.txt --file requirements-dev.txt
         pytest -s -rxs -v cc_plugin_ugrid

--- a/.github/workflows/cc-plugin-glider-test.yml
+++ b/.github/workflows/cc-plugin-glider-test.yml
@@ -3,40 +3,39 @@ name: Glider Plugin Tests
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master,develop,main]
 
 jobs:
   run:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Setup Conda
-      uses: s-weigand/setup-conda@v1
+    - name: Setup Micromamba
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        activate-conda: false
-        conda-channels: conda-forge
+        environment-file: false
 
-    - name: Python ${{ matrix.python-version }}
+    - name: Python
       shell: bash -l {0}
       run: |
-        conda create --name TEST python=${{ matrix.python-version }} python=3 pip --file requirements.txt --file test_requirements.txt --strict-channel-priority
-        source activate TEST
+        micromamba create --name TEST python=3 pip --file requirements.txt --file test_requirements.txt --channel conda-forge
+        micromamba activate TEST
         pip install -e . --no-deps --force-reinstall
 
     - name: Conda Info
       shell: bash -l {0}
       run: |
-        source activate TEST
-        conda info --all
-        conda list
+        micromamba activate TEST
+        micromamba info --all
+        micromamba list
 
     - name: cc-plugin-glider tests
       shell: bash -l {0}
       run: |
-        source activate TEST
+        micromamba activate TEST
         git clone https://github.com/ioos/cc-plugin-glider.git
         cd cc-plugin-glider
-        conda install --file requirements.txt --file requirements-dev.txt ;
+        micromamba install --file requirements.txt --file requirements-dev.txt
         pytest -s -rxs -v cc_plugin_glider

--- a/.github/workflows/cc-plugin-sgrid-test.yml
+++ b/.github/workflows/cc-plugin-sgrid-test.yml
@@ -3,40 +3,39 @@ name: SGRID Plugin Tests
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master,develop,main]
 
 jobs:
   run:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Setup Conda
-      uses: s-weigand/setup-conda@v1
+    - name: Setup Micromamba
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        activate-conda: false
-        conda-channels: conda-forge
+        environment-file: false
 
-    - name: Python ${{ matrix.python-version }}
+    - name: Python
       shell: bash -l {0}
       run: |
-        conda create --name TEST python=${{ matrix.python-version }} python=3 pip --file requirements.txt --file test_requirements.txt --strict-channel-priority
-        source activate TEST
+        micromamba create --name TEST python=3 pip --file requirements.txt --file test_requirements.txt --channel conda-forge
+        micromamba activate TEST
         pip install -e . --no-deps --force-reinstall
 
-    - name: Conda Info
+    - name: micromamba Info
       shell: bash -l {0}
       run: |
-        source activate TEST
-        conda info --all
-        conda list
+        micromamba activate TEST
+        micromamba info --all
+        micromamba list
 
     - name: cc-plugin-glider tests
       shell: bash -l {0}
       run: |
-        source activate TEST
+        micromamba activate TEST
         git clone https://github.com/ioos/cc-plugin-sgrid.git
         cd cc-plugin-sgrid
-        conda install --file requirements.txt --file requirements-dev.txt ;
+        micromamba install --file requirements.txt --file requirements-dev.txt
         pytest -s -rxs -v cc_plugin_sgrid

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -3,46 +3,38 @@ name: Code coverage report
 on:
   pull_request:
   push:
-    branches:
-    - master
-    - develop
+    branches: [master,develop,main]
 
 jobs:
   run:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-        os: [ubuntu-latest]
-      fail-fast: false
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Setup Conda
-      uses: s-weigand/setup-conda@v1
+    - name: Setup Micromamba
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        activate-conda: false
-        conda-channels: conda-forge
+        environment-file: false
 
-    - name: Python ${{ matrix.python-version }}
+    - name: Python
       shell: bash -l {0}
       run: |
-        conda create --name TEST python=${{ matrix.python-version }} pip --file requirements.txt --file test_requirements.txt --strict-channel-priority
-        source activate TEST
+        micromamba create --name TEST python=3 pip --file requirements.txt --file test_requirements.txt --channel conda-forge
+        micromamba activate TEST
         pip install -e . --no-deps --force-reinstall
 
-    - name: Conda Info
+    - name: micromamba Info
       shell: bash -l {0}
       run: |
-        source activate TEST
-        conda info --all
-        conda list
+        micromamba activate TEST
+        micromamba info --all
+        micromamba list
 
     - name: Run tests with coverage
       shell: bash -l {0}
       run: |
-        source activate TEST
+        micromamba activate TEST
         pytest --cov=compliance_checker --cov-report=xml compliance_checker/tests
       # pass this step even if there are individual test failures, we are
       # interested in the overall level of coverage and other checks can
@@ -50,6 +42,6 @@ jobs:
       continue-on-error: true
 
     - name: Upload to codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         files: coverage.xml

--- a/.github/workflows/default-tests.yml
+++ b/.github/workflows/default-tests.yml
@@ -3,7 +3,7 @@ name: Default Tests
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master,develop,main]
 
 jobs:
   run:
@@ -15,30 +15,29 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Setup Conda
-      uses: s-weigand/setup-conda@v1
+    - name: Setup Micromamba
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        activate-conda: false
-        conda-channels: conda-forge
+        environment-file: false
 
     - name: Python ${{ matrix.python-version }}
       shell: bash -l {0}
       run: |
-        conda create --name TEST python=${{ matrix.python-version }} pip --file requirements.txt --file test_requirements.txt --strict-channel-priority
-        source activate TEST
+        micromamba create --name TEST python=${{ matrix.python-version }} pip --file requirements.txt --file test_requirements.txt --channel conda-forge
+        micromamba activate TEST
         pip install -e . --no-deps --force-reinstall
 
-    - name: Conda Info
+    - name: micromamba Info
       shell: bash -l {0}
       run: |
-        source activate TEST
-        conda info --all
-        conda list
+        micromamba activate TEST
+        micromamba info --all
+        micromamba list
 
     - name: Default Tests
       shell: bash -l {0}
       run: |
-        source activate TEST
+        micromamba activate TEST
         pytest -s -rxs -v -k "not integration" compliance_checker

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,30 +10,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Setup Conda
-      uses: s-weigand/setup-conda@v1
+    - name: Setup Micromamba
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        activate-conda: false
-        conda-channels: conda-forge
+        environment-file: false
 
     - name: Python ${{ matrix.python-version }}
       shell: bash -l {0}
       run: |
-        conda create --name TEST python=${{ matrix.python-version }} python=3 pip --file requirements.txt --file test_requirements.txt --strict-channel-priority
-        source activate TEST
+        micromamba create --name TEST python=${{ matrix.python-version }} python=3 pip --file requirements.txt --file test_requirements.txt --channel conda-forge
+        micromamba activate TEST
         pip install -e . --no-deps --force-reinstall
 
-    - name: Conda Info
+    - name: micromamba Info
       shell: bash -l {0}
       run: |
-        source activate TEST
-        conda info --all
-        conda list
+        micromamba activate TEST
+        micromamba info --all
+        micromamba list
 
     - name: Integration Tests
       shell: bash -l {0}
       run: |
-        source activate TEST
+        micromamba activate TEST
         pytest -m "integration" -s -rxs -v --vcr-record=none compliance_checker


### PR DESCRIPTION
In this PR:

1. update the GitHub Actions versions
2. move from conda to micromamba to get faster builds
3. clean up the plugin tests a bit (we created a matrix when we did not really needed it)
4. run the tests on `master`, `main` and `develop` (we should probably get rid of `master` BTW)

This is not ready for review yet. I'll work on caching the environment first to make it easier to re-run tests in a PR.