### PR TITLE
Remove extraneous attribute checks on coordinate variables

### DIFF
--- a/compliance_checker/cfutil.py
+++ b/compliance_checker/cfutil.py
@@ -242,6 +242,7 @@ def is_geophysical(ds, variable):
     return True
 
 
+@lru_cache(128)
 def get_coordinate_variables(ds):
     """
     Returns a list of variable names that identify as coordinate variables.

--- a/compliance_checker/ioos.py
+++ b/compliance_checker/ioos.py
@@ -23,7 +23,6 @@ from compliance_checker.base import (
 from compliance_checker.cf import util as cf_util  # not to be confused with cfutil.py
 from compliance_checker.cf.cf import CF1_6Check, CF1_7Check
 from compliance_checker.cfutil import (
-    get_coordinate_variables,
     get_geophysical_variables,
     get_instrument_variables,
     get_z_variables,
@@ -487,9 +486,6 @@ class IOOS1_2Check(IOOSNCCheck):
             )
         )
 
-        # geospatial vars must have the following attrs:
-        self.geospat_check_var_attrs = self._default_check_var_attrs
-
         # valid contributor_role values
         self.valid_contributor_roles = set(
             [  # NERC and NOAA
@@ -850,23 +846,6 @@ class IOOS1_2Check(IOOSNCCheck):
             )
 
         return results
-
-    def check_geospatial_vars_have_attrs(self, ds):
-        """
-        All geospatial variables must have certain attributes.
-
-        Parameters
-        ----------
-        ds: netCDF4.Dataset
-
-        Returns
-        -------
-        list: list of Result objects
-        """
-
-        return self._check_vars_have_attrs(
-            ds, get_coordinate_variables(ds), self.geospat_check_var_attrs
-        )
 
     def _check_vars_have_attrs(self, ds, vars_to_check, atts_to_check):
         """


### PR DESCRIPTION
Removes checks for _FillValue and missing_value on coordinate variables
in IOOS profile checker which should not take place per CF Conventions
section 2.5.1.