### PR TITLE
Updated check_compression_gathering

### DIFF
--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -3287,7 +3287,23 @@ class CF1_6Check(CFNCCheck):
                         compress_var.name, not_in_dims
                     )
                 )
-
+            # IMPLEMENTATION CONFORMANCE 8.2 REQUIRED 3/3
+            # The values of the associated coordinate variable must be in the range 
+            # starting with 0 and going up to the product of the compressed dimension 
+            # sizes minus 1 (CDL index conventions).
+            
+            # Put the the values of the associated coordinate variable into a list
+            coord_list_size = [item.size for item in ds.dimensions.values() if item.name in compress_set]
+            # get the uppper limt of the dimenssion size
+            upper_limit_size = np.prod(coord_list_size) - 1
+            
+            for coord_size in coord_list_size:
+                if coord_size not in range(0,upper_limit_size): 
+                    valid = False
+                    reasoning.append(
+                            'The dimenssion size {} referenced by the commpress attribute is not ' 
+                            'in the range (0, The product of the compressed dimension sizes minus 1)'.format(coord_size)
+                            )
             result = Result(
                 BaseCheck.MEDIUM, valid, self.section_titles["8.2"], reasoning
             )

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -3294,19 +3294,17 @@ class CF1_6Check(CFNCCheck):
             
             # Put the the values of the associated coordinate variable into a list
             coord_list_size = [item.size for item in ds.dimensions.values() if item.name in compress_set]
-            # get the uppper limt of the dimenssion size
+            # get the upper limt of the dimenssion size
             upper_limit_size = np.prod(coord_list_size) - 1
             
             for coord_size in coord_list_size:
                 if coord_size not in range(0,upper_limit_size): 
                     valid = False
                     reasoning.append(
-                            'The dimenssion size {} referenced by the commpress attribute is not ' 
+                            'The dimenssion size {} referenced by the compress attribute is not ' 
                             'in the range (0, The product of the compressed dimension sizes minus 1)'.format(coord_size)
                             )
-            result = Result(
-                BaseCheck.MEDIUM, valid, self.section_titles["8.2"], reasoning
-            )
+            result = Result(BaseCheck.MEDIUM, valid, self.section_titles["8.2"], reasoning)
             ret_val.append(result)
 
         return ret_val

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -7,7 +7,7 @@ import regex
 from cf_units import Unit
 
 from compliance_checker import cfutil
-from compliance_checker.base import BaseCheck Result TestCtx
+from compliance_checker.base import BaseCheck, Result, TestCtx
 from compliance_checker.cf import util
 from compliance_checker.cf.appendix_c import valid_modifiers
 from compliance_checker.cf.appendix_d import dimless_vertical_coordinates_1_6
@@ -403,7 +403,7 @@ class CF1_6Check(CFNCCheck):
                     ),
                 )
         return valid_dimension_order.to_result()
-
+        
     def check_fill_value_outside_valid_range(self, ds):
         """
         Checks each variable's _FillValue to ensure that it's in valid_range or

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -3362,23 +3362,31 @@ class CF1_6Check(CFNCCheck):
                     )
                 )
             # IMPLEMENTATION CONFORMANCE 8.2 REQUIRED 3/3
-            # The values of the associated coordinate variable must be in the range 
-            # starting with 0 and going up to the product of the compressed dimension 
+            # The values of the associated coordinate variable must be in the range
+            # starting with 0 and going up to the product of the compressed dimension
             # sizes minus 1 (CDL index conventions).
-            
+
             # Put the the values of the associated coordinate variable into a list
-            coord_list_size = [item.size for item in ds.dimensions.values() if item.name in compress_set]
+            coord_list_size = [
+                item.size
+                for item in ds.dimensions.values()
+                if item.name in compress_set
+            ]
             # get the upper limt of the dimenssion size
             upper_limit_size = np.prod(coord_list_size) - 1
-            
+
             for coord_size in coord_list_size:
-                if coord_size not in range(0,upper_limit_size): 
+                if coord_size not in range(0, upper_limit_size):
                     valid = False
                     reasoning.append(
-                            'The dimenssion size {} referenced by the compress attribute is not ' 
-                            'in the range (0, The product of the compressed dimension sizes minus 1)'.format(coord_size)
-                            )
-            result = Result(BaseCheck.MEDIUM, valid, self.section_titles["8.2"], reasoning)
+                        "The dimenssion size {} referenced by the compress attribute is not "
+                        "in the range (0, The product of the compressed dimension sizes minus 1)".format(
+                            coord_size
+                        )
+                    )
+            result = Result(
+                BaseCheck.MEDIUM, valid, self.section_titles["8.2"], reasoning
+            )
             ret_val.append(result)
 
         return ret_val

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -7,7 +7,7 @@ import regex
 from cf_units import Unit
 
 from compliance_checker import cfutil
-from compliance_checker.base import BaseCheck, Result, TestCtx
+from compliance_checker.base import BaseCheck Result, TestCtx
 from compliance_checker.cf import util
 from compliance_checker.cf.appendix_c import valid_modifiers
 from compliance_checker.cf.appendix_d import dimless_vertical_coordinates_1_6
@@ -431,11 +431,10 @@ class CF1_6Check(CFNCCheck):
             if "valid_range" in attrs:
                 if isinstance(variable.valid_range, str):
                     m = "§2.5.1 Fill Values should be outside the range specified by valid_range"  # subsection message
-                    valid_fill_range.assert_true(
+                    valid_fill_range.assert_true
+                    (
                         False,
-                        "{};\n\t{}:valid_range must be a numeric type not a string".format(
-                            m, name
-                        ),
+                        "{}; \n\t{}:valid_range must be a numeric type not a string".format(m, name),
                     )
                     continue
                 rmin, rmax = variable.valid_range
@@ -443,12 +442,14 @@ class CF1_6Check(CFNCCheck):
 
             elif "valid_min" in attrs and "valid_max" in attrs:
                 if isinstance(variable.valid_min, str):
-                    valid_fill_range.assert_true(
+                    valid_fill_range.assert_true
+                    (
                         False,
                         "{}:valid_min must be a numeric type not a string".format(name),
                     )
                 if isinstance(variable.valid_max, str):
-                    valid_fill_range.assert_true(
+                    valid_fill_range.assert_true
+                    (
                         False,
                         "{}:valid_max must be a numeric type not a string".format(name),
                     )
@@ -467,7 +468,8 @@ class CF1_6Check(CFNCCheck):
             else:
                 valid = fill_value < rmin or fill_value > rmax
 
-            valid_fill_range.assert_true(
+            valid_fill_range.assert_true
+            (
                 valid,
                 "{}:_FillValue ({}) should be outside the range specified by {} ({}, {})"
                 "".format(name, fill_value, spec_by, rmin, rmax),
@@ -3363,13 +3365,15 @@ class CF1_6Check(CFNCCheck):
         for variable in ds.get_variables_by_attributes(cf_role=lambda x: x is not None):
             variable_count += 1
             cf_role = variable.cf_role
-            valid_cf_role.assert_true(
+            valid_cf_role.assert_true
+            (
                 cf_role in valid_roles,
                 "{} is not a valid cf_role value. It must be one of {}"
                 "".format(cf_role, ", ".join(valid_roles)),
             )
         if variable_count > 0:
-            m = (
+            m = 
+            (
                 "§9.5 The only acceptable values of cf_role for Discrete Geometry CF"
                 + " data sets are timeseries_id, profile_id, and trajectory_id"
             )

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -7,7 +7,7 @@ import regex
 from cf_units import Unit
 
 from compliance_checker import cfutil
-from compliance_checker.base import BaseCheck Result, TestCtx
+from compliance_checker.base import BaseCheck Result TestCtx
 from compliance_checker.cf import util
 from compliance_checker.cf.appendix_c import valid_modifiers
 from compliance_checker.cf.appendix_d import dimless_vertical_coordinates_1_6
@@ -431,10 +431,11 @@ class CF1_6Check(CFNCCheck):
             if "valid_range" in attrs:
                 if isinstance(variable.valid_range, str):
                     m = "§2.5.1 Fill Values should be outside the range specified by valid_range"  # subsection message
-                    valid_fill_range.assert_true
-                    (
+                    valid_fill_range.assert_true(
                         False,
-                        "{}; \n\t{}:valid_range must be a numeric type not a string".format(m, name),
+                        "{};\n\t{}:valid_range must be a numeric type not a string".format(
+                            m, name
+                        ),
                     )
                     continue
                 rmin, rmax = variable.valid_range
@@ -442,14 +443,12 @@ class CF1_6Check(CFNCCheck):
 
             elif "valid_min" in attrs and "valid_max" in attrs:
                 if isinstance(variable.valid_min, str):
-                    valid_fill_range.assert_true
-                    (
+                    valid_fill_range.assert_true(
                         False,
                         "{}:valid_min must be a numeric type not a string".format(name),
                     )
                 if isinstance(variable.valid_max, str):
-                    valid_fill_range.assert_true
-                    (
+                    valid_fill_range.assert_true(
                         False,
                         "{}:valid_max must be a numeric type not a string".format(name),
                     )
@@ -468,8 +467,7 @@ class CF1_6Check(CFNCCheck):
             else:
                 valid = fill_value < rmin or fill_value > rmax
 
-            valid_fill_range.assert_true
-            (
+            valid_fill_range.assert_true(
                 valid,
                 "{}:_FillValue ({}) should be outside the range specified by {} ({}, {})"
                 "".format(name, fill_value, spec_by, rmin, rmax),
@@ -3365,15 +3363,13 @@ class CF1_6Check(CFNCCheck):
         for variable in ds.get_variables_by_attributes(cf_role=lambda x: x is not None):
             variable_count += 1
             cf_role = variable.cf_role
-            valid_cf_role.assert_true
-            (
+            valid_cf_role.assert_true(
                 cf_role in valid_roles,
                 "{} is not a valid cf_role value. It must be one of {}"
                 "".format(cf_role, ", ".join(valid_roles)),
             )
         if variable_count > 0:
-            m = 
-            (
+            m = (
                 "§9.5 The only acceptable values of cf_role for Discrete Geometry CF"
                 + " data sets are timeseries_id, profile_id, and trajectory_id"
             )


### PR DESCRIPTION
Related to [issue#956] (https://github.com/ioos/compliance-checker/issues/956) Solving:
- [ ] The values of the associated coordinate variable must be in the range starting with 0 and going up to the product of the compressed dimension sizes minus 1 (CDL index conventions).