### PR TITLE
updated check_cell_measures

### DIFF
--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -2663,20 +2663,20 @@ class CF1_6Check(CFNCCheck):
                         )
                     else:
                         # IMPLEMENTATION CONFORMANCE REQUIRED 2/2
-                        # verify this combination {area: 'm2', volume: 'm3'} 
-                        dic_expected = {'area': 'm2', 'volume': 'm3'}
-                        dic_to_be_verified = {(var.cell_measures).split(':')[0]: cell_meas_var.units}                  
-                        print(dic_to_be_verified,'\n') 
+                        # verify this combination {area: 'm2', volume: 'm3'}
+                        dic_expected = {"area": "m2", "volume": "m3"}
+                        dic_to_be_verified = {
+                            (var.cell_measures).split(":")[0]: cell_meas_var.units
+                        }
+                        print(dic_to_be_verified, "\n")
                         if not set(dic_to_be_verified).issubset(dic_expected):
                             valid = False
                             reasoning.append(
-                            "Cell measure variable {} must have "
-                            "units that are consistent with the measure type."
-                            "i.e. {}.".format(
-                                cell_meas_var_name, dic_expected
+                                "Cell measure variable {} must have "
+                                "units that are consistent with the measure type."
+                                "i.e. {}.".format(cell_meas_var_name, dic_expected)
                             )
-                        )
-                        
+
                     if not set(cell_meas_var.dimensions).issubset(var.dimensions):
                         valid = False
                         reasoning.append(

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -2661,6 +2661,22 @@ class CF1_6Check(CFNCCheck):
                                 cell_meas_var_name
                             )
                         )
+                    else:
+                        # IMPLEMENTATION CONFORMANCE REQUIRED 2/2
+                        # verify this combination {area: 'm2', volume: 'm3'} 
+                        dic_expected = {'area': 'm2', 'volume': 'm3'}
+                        dic_to_be_verified = {(var.cell_measures).split(':')[0]: cell_meas_var.units}                  
+                        print(dic_to_be_verified,'\n') 
+                        if not set(dic_to_be_verified).issubset(dic_expected):
+                            valid = False
+                            reasoning.append(
+                            "Cell measure variable {} must have "
+                            "units that are consistent with the measure type."
+                            "i.e. {}.".format(
+                                cell_meas_var_name, dic_expected
+                            )
+                        )
+                        
                     if not set(cell_meas_var.dimensions).issubset(var.dimensions):
                         valid = False
                         reasoning.append(


### PR DESCRIPTION
This is in reference to [issue #953](https://github.com/ioos/compliance-checker/issues/953)

Updated the function "check_cell_measures" to include:
- [ ] A measure variable must have units that are consistent with the measure type, i.e., square meters for area measures and cubic meters for volume measures.