### PR TITLE
Fix calendar crossing 1582 issue on some builds

### DIFF
--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -1831,22 +1831,19 @@ class CF1_6Check(CFNCCheck):
             # should be made for time coordinate variables anyways, so errors
             # should be caught where implemented there
             crossover_date = cftime.DatetimeGregorian(1582, 10, 15)
-            times = cftime.num2date(time_var[:], time_var.units)
+            times = cftime.num2date(time_var[:].compressed(), time_var.units)
 
-            # appears to be necessary to override supplied _FillValue of "?"
-            # FillValues shouldn't fail, so set to crossover date to pass
-            times.set_fill_value(crossover_date)
             no_cross_1582 = ~np.any(times < crossover_date)
             if no_cross_1582:
                 reasoning = (
-                    f"Variable {time_var.name} has standard/gregorian "
+                    f"Variable {time_var.name} has standard or Gregorian "
                     "calendar and does not cross 1582-10-15T00:00Z"
                 )
             else:
                 reasoning = (
                     f"Variable {time_var.name} has time values "
                     "prior to 1582-10-15T00:00Z and utilizes "
-                    "the standard/gregorian calendar"
+                    "the standard or Gregorian calendar"
                 )
 
             return Result(

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1244,20 +1244,22 @@ class TestCF1_6(BaseTestCase):
             dataset.variables["time"].calendar = calendar
             dataset.variables["time"].units = "seconds since 1582-10-15T00:00Z"
             # 500 element array with some failing values
+            # _FillValue at first element even though should not be present
+            # in time coordinate variable to test bad data handling
             # TEST CONFORMANCE 4.4.1 RECOMMENDED 4/4
-            dataset.variables["time"][:] = np.arange(-2, 498)
+            dataset.variables["time"][1:] = np.arange(-2, 497)
             results = self.cf.check_calendar(dataset)
             scored, out_of, messages = get_results(results)
             assert messages[-1] == (
                 "Variable time has time values prior to "
                 "1582-10-15T00:00Z and utilizes the "
-                "standard/gregorian calendar"
+                "standard or Gregorian calendar"
             )
             dataset.variables["time"][:] = np.arange(0, 500)
             results = self.cf.check_calendar(dataset)
             scored, out_of, messages = get_results(results)
             assert messages[-1] == (
-                "Variable time has standard/gregorian "
+                "Variable time has standard or Gregorian "
                 "calendar and does not cross 1582-10-15T00:00Z"
             )
             # TEST CONFORMANCE 4.4.1 RECOMMENDED 3/4


### PR DESCRIPTION
@mhidas, should address issue mentioned in #986 by using an alternative implementation for excluding _FillValue time data.