### PR TITLE
Exclude miscellaneous files from being checked by codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,8 +42,10 @@ repos:
           (?x)^(
               .*\.xml|
               .*\.cdl|
-              .*_version.py|
-              .*versioneer.py
+              .*_version\.py|
+              .*versioneer\.py|
+              compliance_checker/tests/cassettes/test_netcdf_content_type\.yaml|
+              compliance_checker/data/seanames\.csv
           )$
 
 ci:


### PR DESCRIPTION
Excludes seanames.csv and a testing configuration file from codespell pre-commit checking.