### PR TITLE
Implement majority of conformance for CF section 4.4

### DIFF
--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -1923,9 +1923,22 @@ class CF1_6Check(CFNCCheck):
             # has_year_zero set to true in order to just check crossover,
             # actual year less than or equal to zero check handled elsewhere
             # when standard/Gregorian, or Julian calendars used.
-            times = cftime.num2date(
-                time_var[:].compressed(), time_var.units, has_year_zero=True
-            )
+
+            # WARNING: might fail here if months_since are used and suppress
+            #          usual warning
+            try:
+                times = cftime.num2date(
+                    time_var[:].compressed(), time_var.units, has_year_zero=True
+                )
+            except ValueError:
+                return Result(
+                    BaseCheck.LOW,
+                    False,
+                    self.section_titles["4.4"],
+                    [
+                        "Miscellaneous failure when attempting to calculate crossover, possible malformed date"
+                    ],
+                )
 
             crossover_1582 = np.any(times < crossover_date) and np.any(
                 times >= crossover_date

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -1,13 +1,11 @@
 import difflib
 import logging
 from collections import defaultdict
-from typing import List
 
 import cftime
 import numpy as np
 import regex
 from cf_units import Unit
-from netCDF4 import Variable
 
 from compliance_checker import cfutil
 from compliance_checker.base import BaseCheck, Result, TestCtx
@@ -1854,10 +1852,6 @@ class CF1_6Check(CFNCCheck):
                 ret_val.append(result)
         return ret_val
 
-    # dummy return, implemented in CF >= 1.9
-    def _calendar_invalid(self, time_var: Variable) -> List[str]:
-        return []
-
     def check_calendar(self, ds):
         """
         Check the calendar attribute for variables defining time and ensure it
@@ -1976,15 +1970,7 @@ class CF1_6Check(CFNCCheck):
             if time_var_name not in {var.name for var in util.find_coord_vars(ds)}:
                 continue
             time_var = ds.variables[time_var_name]
-            if not hasattr(time_var, "calendar") or not isinstance(
-                time_var.calendar, str
-            ):
-                reasoning_list = self._calendar_invalid(time_var)
-
-                result = Result(
-                    BaseCheck.MEDIUM, True, self.section_titles["4.4.1"], reasoning_list
-                )
-                ret_val.append(result)
+            if not hasattr(time_var, "calendar"):
                 continue
             if time_var.calendar.lower() == "gregorian":
                 reasoning = (

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -1968,6 +1968,8 @@ class CF1_6Check(CFNCCheck):
         # this will only fetch variables with time units defined
         for time_var_name in cfutil.get_time_variables(ds):
             time_var = ds.variables[time_var_name]
+            if time_var not in util.find_coord_vars(ds):
+                continue
             if not hasattr(time_var, "calendar") or not isinstance(
                 time_var.calendar, str
             ):

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -1952,9 +1952,22 @@ class CF1_6Check(CFNCCheck):
         # if has a calendar, check that it is within the valid values
         # otherwise no calendar is valid
 
-        for time_var in ds.get_variables_by_attributes(
-            calendar=lambda c: c is not None
-        ):
+        # this will only fetch variables with time units defined
+        for time_var_name in cfutil.get_time_variables(ds):
+            time_var = ds.variables[time_var_name]
+            if not hasattr(time_var, "calendar") or not isinstance(
+                time_var.calendar, str
+            ):
+                reasoning = (
+                    f'For time coordinate variable "{time_var.name}", '
+                    'it is recommended that an attribute "calendar" '
+                    "with a string value is specified"
+                )
+                result = Result(
+                    BaseCheck.MEDIUM, False, self.section_titles["4.4.1"], [reasoning]
+                )
+                ret_val.append(result)
+                continue
             if time_var.calendar.lower() == "gregorian":
                 reasoning = (
                     f"For time variable {time_var.name}, when using "
@@ -1963,7 +1976,7 @@ class CF1_6Check(CFNCCheck):
                     "the calendar attribute"
                 )
                 result = Result(
-                    BaseCheck.LOW, False, self.section_titles["4.4"], [reasoning]
+                    BaseCheck.LOW, False, self.section_titles["4.4.1"], [reasoning]
                 )
                 ret_val.append(result)
                 # check here and in the below case that time does not cross
@@ -1978,7 +1991,7 @@ class CF1_6Check(CFNCCheck):
             # passes if the calendar is valid, otherwise notify of invalid
             # calendar
             else:
-                result = Result(BaseCheck.LOW, True, self.section_titles["4.4"], None)
+                result = Result(BaseCheck.LOW, True, self.section_titles["4.4.1"])
             ret_val.append(result)
 
         return ret_val

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -1826,41 +1826,30 @@ class CF1_6Check(CFNCCheck):
                 )
                 ret_val.append(result)
                 continue
-            # TODO: Is this a reasonable regex for extracting reference time
-            #       fields of interest?  Was unable to locate the grammar
-            #       or documentation for how reference times should be formed
-            time_regex = regex.compile(
-                r"(?P<time_interval>(\w+)) since "
-                r"(?P<year>\d{1,4})-\d{1,2}-\d{1,2}(?:[ T]"
-                r"\d{1,2}:(?P<minutes>\d{1,2})?)?"
-            )
-            match_vals = regex.match(time_regex, variable.units)
-            time_interval = match_vals.group("time_interval")
-            # IMPLEMENTATION CONFORMANCE 4.4 RECOMMENDED 2/2
-            if time_interval.startswith("month") or time_interval.startswith("year"):
-                msg = f"Using relative time interval of months or years is not recommended for coordinate variable {variable.name}"
-                result = Result(
-                    BaseCheck.MEDIUM, False, self.section_titles["4.4"], [msg]
-                )
-                ret_val.append(result)
             # IMPLEMENTATION CONFORMANCE 4.4 RECOMMENDED 1/2
-            if hasattr(variable, "climatology") and int(match_vals.group("year")) == 0:
-                msg = f"Time coordinate variable {variable.name}'s use of year 0 for climatological time is deprecated"
+            if hasattr(variable, "climatology"):
+                year_match = regex.match(r"\w+ since (?P<year>\d{1,4})", variable.units)
+                # year should always exist at this point if it's been parsed as
+                # valid date
+                if int(year_match.group("year")) == 0:
+                    message = (
+                        f"Time coordinate variable {variable.name}'s "
+                        "use of year 0 for climatological time is "
+                        "deprecated"
+                    )
+                    result = Result(
+                        BaseCheck.MEDIUM, False, self.section_titles["4.4"], [message]
+                    )
+                    ret_val.append(result)
+            # IMPLEMENTATION CONFORMANCE 4.4 RECOMMENDED 2/2
+            # catch non-recommended months or years time interval
+            unit = Unit(variable.units)
+            if unit.is_long_time_interval():
+                message = f"Using relative time interval of months or years is not recommended for coordinate variable {variable.name}"
                 result = Result(
-                    BaseCheck.MEDIUM, False, self.section_titles["4.4"], [msg]
+                    BaseCheck.MEDIUM, False, self.section_titles["4.4"], [message]
                 )
                 ret_val.append(result)
-            # IMPLEMENTATION CONFORMANCE 4.4 REQUIRED 2/2
-            if (
-                match_vals.group("minutes") is not None
-                and int(match_vals.group("minutes")) >= 60
-            ):
-                msg = f"Time coordinate variable {variable.name} may not have a minute value greater than or equal to 60"
-                result = Result(
-                    BaseCheck.MEDIUM, False, self.section_titles["4.4"], [msg]
-                )
-                ret_val.append(result)
-
         return ret_val
 
     def check_calendar(self, ds):

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -1894,7 +1894,7 @@ class CF1_6Check(CFNCCheck):
         :rtype: list
         :return: List of results
         """
-        valid_calendars = {
+        standard_calendars = {
             "gregorian",
             "standard",
             "proleptic_gregorian",
@@ -1963,7 +1963,7 @@ class CF1_6Check(CFNCCheck):
                 ret_val.append(check_standard_calendar_no_cross(time_var))
             # if a nonstandard calendar, then leap_years and leap_months must
             # must be present
-            if time_var.calendar.lower() not in valid_calendars:
+            if time_var.calendar.lower() not in standard_calendars:
                 result = self._check_leap_time(time_var)
             # passes if the calendar is valid, otherwise notify of invalid
             # calendar

--- a/compliance_checker/cf/cf_base.py
+++ b/compliance_checker/cf/cf_base.py
@@ -58,6 +58,7 @@ class CFBaseCheck(BaseCheck):
             "4.2": "§4.2 Longitude Coordinate",
             "4.3": "§4.3 Vertical Coordinate",
             "4.4": "§4.4 Time Coordinate",
+            "4.4.1": "§4.4.1 Calendar",
             "4.5": "§4.5 Discrete Axis",
             "5": "§5 Coordinate Systems",
             "5.1": "§5.1 Independent Latitude, Longitude, Vertical, and Time Axes",

--- a/compliance_checker/tests/helpers.py
+++ b/compliance_checker/tests/helpers.py
@@ -46,6 +46,7 @@ class MockTimeSeries(MockNetCDF):
         # give some applicable units
         self.variables["time"].units = "seconds since 2019-04-11T00:00:00"
         self.variables["time"].axis = "T"
+        self.variables["time"].calendar = "standard"
         self.variables["lat"].units = "degree_north"
         self.variables["lat"].axis = "Y"
         self.variables["lon"].units = "degree_east"

--- a/compliance_checker/tests/helpers.py
+++ b/compliance_checker/tests/helpers.py
@@ -44,15 +44,7 @@ class MockTimeSeries(MockNetCDF):
             var.axis = axis
 
         # give some applicable units
-        self.variables["time"].units = "seconds since 2019-04-11T00:00:00"
-        self.variables["time"].axis = "T"
         self.variables["time"].calendar = "standard"
-        self.variables["lat"].units = "degree_north"
-        self.variables["lat"].axis = "Y"
-        self.variables["lon"].units = "degree_east"
-        self.variables["lon"].axis = "X"
-        self.variables["depth"].units = "meters"
-        self.variables["depth"].axis = "Z"
         self.variables["depth"].positive = "down"
 
 

--- a/compliance_checker/tests/helpers.py
+++ b/compliance_checker/tests/helpers.py
@@ -31,7 +31,7 @@ class MockTimeSeries(MockNetCDF):
         super(MockTimeSeries, self).__init__(filename)
         self.createDimension("time", 500)
         for name, std_name, units, axis in (
-            ("time", "time", "seconds since 1970-01-01", "T"),
+            ("time", "time", "seconds since 1970-01-01 00:00:00", "T"),
             ("lon", "longitude", "degrees_east", "X"),
             ("lat", "latitude", "degrees_north", "Y"),
             ("depth", "depth", "m", "Z"),

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1279,7 +1279,15 @@ class TestCF1_6(BaseTestCase):
         assert bad_month_msg in messages
 
         dataset = MockTimeSeries()
-        dataset.variables["time"]
+        # no calendar should raise an issue on time coordinate variables
+        del dataset.variables["time"].calendar
+        results = self.cf.check_calendar(dataset)
+        scored, out_of, messages = get_results(results)
+        assert (
+            'For time coordinate variable "time", it is recommended that '
+            'an attribute "calendar" with a string value is specified' in messages
+        )
+
         # test case insensivity
         valid_calendars = (
             "GREGORIAN",
@@ -1294,6 +1302,10 @@ class TestCF1_6(BaseTestCase):
             "NONE",
         )
         for calendar_uppercase in valid_calendars:
+            # need to make a new MockTimeSeries when attribute deleted for
+            # calendar attributes to work properly
+            dataset = MockTimeSeries()
+            dataset.calendar = calendar_uppercase
             results = self.cf.check_calendar(dataset)
             scored, out_of, messages = get_results(results)
             assert scored == out_of

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1243,6 +1243,8 @@ class TestCF1_6(BaseTestCase):
         assert (scored, out_of) == (1, 2)
         # TEST CONFORMANCE 4.4 REQUIRED 2/2, RECOMMENDED 1, 2/2
         dataset = MockTimeSeries()
+        # NB: >= 60 seconds is nonstandard, but isn't actually a CF requirement
+        # until CF 1.9 onwards
         dataset.variables["time"].units = "months since 0-1-1 23:60:00"
         dataset.variables[
             "time"

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1279,14 +1279,11 @@ class TestCF1_6(BaseTestCase):
         assert bad_month_msg in messages
 
         dataset = MockTimeSeries()
-        # no calendar should raise an issue on time coordinate variables
+        # no calendar should not raise an issue on time coordinate variables
         del dataset.variables["time"].calendar
         results = self.cf.check_calendar(dataset)
         scored, out_of, messages = get_results(results)
-        assert (
-            'For time coordinate variable "time", it is recommended that '
-            'an attribute "calendar" with a string value is specified' in messages
-        )
+        assert not messages
 
         # test case insensivity
         valid_calendars = (
@@ -3030,10 +3027,12 @@ class TestCF1_9(BaseTestCase):
     def test_time_variable_has_calendar(self):
         # TEST CONFORMANCE 4.4.1 RECOMMENDED CF 1.9
         dataset = MockTimeSeries()
+        del dataset.variables["time"].calendar
         results = self.cf.check_calendar(dataset)
-        assert (
-            results[0].msgs[0] == 'Time coordinate variable "time" should have a '
-            "calendar attribute"
+        assert results[0].msgs[0] == (
+            'For time coordinate variable "time", it is '
+            'recommended that an attribute "calendar" '
+            "with a string value is specified"
         )
         # FIXME: NetCDF files shouldn't normally be modified so we can usually
         # depend on cached results. Here we need to recreate the checker

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -3073,7 +3073,20 @@ class TestCF1_9(BaseTestCase):
         results = self.cf.check_calendar(dataset)
         scored, out_of, messages = get_results(results)
 
-        "Time coordinate variable time's use of year 0 for climatological time is deprecated",
+        # test greater than or equal to one zero year for Julian and Gregorian
+        # calendars
+        dataset = MockTimeSeries()
+        dataset.variables["time"].units = "seconds since 0-01-01 00:00:00"
+        for calendar_name in ("standard", "julian", "gregorian"):
+            dataset.variables["time"].calendar = calendar_name
+            results = self.cf.check_time_coordinate_variable_has_calendar(dataset)
+            scored, out_of, messages = get_results(results)
+            assert (
+                'For time variable "time", when using the Gregorian or Julian '
+                "calendars, the use of year zero is not recommended. "
+                "Furthermore, the use of year zero to signify a climatological "
+                "variable as in COARDS is deprecated in CF." in messages
+            )
 
     def test_domain(self):
         dataset = MockTimeSeries()

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1233,6 +1233,7 @@ class TestCF1_6(BaseTestCase):
         for r in results:
             self.assertTrue(r.value)
 
+        # TEST CONFORMANCE 4.4 REQUIRED 1/2
         dataset = self.load_dataset(STATIC_FILES["bad"])
         results = self.cf.check_time_coordinate(dataset)
 
@@ -1240,6 +1241,22 @@ class TestCF1_6(BaseTestCase):
 
         assert "time does not have correct time units" in messages
         assert (scored, out_of) == (1, 2)
+        # TEST CONFORMANCE 4.4 REQUIRED 2/2, RECOMMENDED 1, 2/2
+        dataset = MockTimeSeries()
+        dataset.variables["time"].units = "months since 0-1-1 23:60:00"
+        dataset.variables[
+            "time"
+        ].climatology = (
+            "nonexistent_variable_reference_only_used_to_test_year_zero_failure"
+        )
+        results = self.cf.check_time_coordinate(dataset)
+        scored, out_of, messages = get_results(results)
+        assert scored < out_of
+        assert {
+            "Using relative time interval of months or years is not recommended for coordinate variable time",
+            "Time coordinate variable time's use of year 0 for climatological time is deprecated",
+            "Time coordinate variable time may not have a minute value greater than or equal to 60",
+        } == set(messages)
 
     def test_check_calendar(self):
         """Load a dataset with an invalid calendar attribute (non-comp/bad.nc).

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1255,7 +1255,6 @@ class TestCF1_6(BaseTestCase):
         assert {
             "Using relative time interval of months or years is not recommended for coordinate variable time",
             "Time coordinate variable time's use of year 0 for climatological time is deprecated",
-            "Time coordinate variable time may not have a minute value greater than or equal to 60",
         } == set(messages)
 
     def test_check_calendar(self):

--- a/compliance_checker/tests/test_cf_integration.py
+++ b/compliance_checker/tests/test_cf_integration.py
@@ -22,7 +22,7 @@ dataset_stem__expected_messages = [
             "attribute lat:_CoordianteAxisType should begin with a letter and be composed of letters, digits, and underscores",
             "attribute lon:_CoordianteAxisType should begin with a letter and be composed of letters, digits, and underscores",
             "§2.6.2 global attribute history should exist and be a non-empty string",
-            "standard_name temperature is not defined in Standard Name Table v{}".format(
+            "standard_name temperature is not defined in Standard Name Table v{}. Possible close match(es): ['air_temperature', 'soil_temperature', 'snow_temperature']".format(
                 std_names._version
             ),
             "temperature's auxiliary coordinate specified by the coordinates attribute, precise_lat, is not a variable in this dataset",
@@ -46,28 +46,28 @@ dataset_stem__expected_messages = [
             "Attribute 'valid_range' (type: <class 'numpy.int16'>) and parent variable 'wind_direction_qc' (type: <class 'numpy.int8'>) must have equivalent datatypes",
             "Attribute 'valid_range' (type: <class 'numpy.int16'>) and parent variable 'visibility_qc' (type: <class 'numpy.int8'>) must have equivalent datatypes",
             '§2.6.1 Conventions global attribute does not contain "CF-1.8"',
-            "standard_name visibility is not defined in Standard Name Table v{}".format(
+            "standard_name visibility is not defined in Standard Name Table v{}. Possible close match(es): ['visibility_in_air']".format(
                 std_names._version
             ),
             'Standard name modifier "data_quality" for variable visibility_qc is not a valid modifier according to CF Appendix C',
-            "standard_name wind_direction is not defined in Standard Name Table v{}".format(
+            "standard_name wind_direction is not defined in Standard Name Table v{}. Possible close match(es): ['wind_to_direction', 'wind_from_direction', 'wind_gust_from_direction']".format(
                 std_names._version
             ),
             'Standard name modifier "data_quality" for variable wind_direction_qc is not a valid modifier according to CF Appendix C',
-            "standard_name wind_gust is not defined in Standard Name Table v{}".format(
+            "standard_name wind_gust is not defined in Standard Name Table v{}. Possible close match(es): ['y_wind_gust', 'x_wind_gust', 'wind_speed_of_gust']".format(
                 std_names._version
             ),
             'Standard name modifier "data_quality" for variable wind_gust_qc is not a valid modifier according to CF Appendix C',
             'Standard name modifier "data_quality" for variable air_temperature_qc is not a valid modifier according to CF Appendix C',
-            "standard_name use_wind is not defined in Standard Name Table v{}".format(
+            "standard_name use_wind is not defined in Standard Name Table v{}. Possible close match(es): ['y_wind', 'x_wind']".format(
                 std_names._version
             ),
-            "standard_name barometric_pressure is not defined in Standard Name Table v{}".format(
+            "standard_name barometric_pressure is not defined in Standard Name Table v{}. Possible close match(es): ['air_pressure', 'reference_pressure', 'barometric_altitude']".format(
                 std_names._version
             ),
             'Standard name modifier "data_quality" for variable barometric_pressure_qc is not a valid modifier according to CF Appendix C',
             'Standard name modifier "data_quality" for variable wind_speed_qc is not a valid modifier according to CF Appendix C',
-            "standard_name barometric_pressure is not defined in Standard Name Table v{}".format(
+            "standard_name barometric_pressure is not defined in Standard Name Table v{}. Possible close match(es): ['air_pressure', 'reference_pressure', 'barometric_altitude']".format(
                 std_names._version
             ),
             "CF recommends latitude variable 'lat' to use units degrees_north",
@@ -152,10 +152,10 @@ dataset_stem__expected_messages = [
         [
             # TODO: referenced/relative time is treated like time units
             'Units "hours since 2016-01-01T12:00:00Z" for variable time_offset must be convertible to canonical units "s"',
-            "standard_name cloud_cover is not defined in Standard Name Table v{}".format(
+            "standard_name cloud_cover is not defined in Standard Name Table v{}. Possible close match(es): ['land_cover', 'land_cover_lccs', 'cloud_albedo']".format(
                 std_names._version
             ),
-            "standard_name dew_point is not defined in Standard Name Table v{}".format(
+            "standard_name dew_point is not defined in Standard Name Table v{}. Possible close match(es): ['dew_point_depression', 'dew_point_temperature']".format(
                 std_names._version
             ),
             (


### PR DESCRIPTION
Adds implementations and tests for the following sections:

Required:
- The reference date/time in time units is not allowed to contain seconds equal to or greater than 60.

Recommendations:
- The use of time coordinates in year 0 and reference date/times in year 0 to indicate climatological time is deprecated.
- Units of year and month and any equivalent units should be used with caution.