### PR TITLE
Pin isodate >= 0.6.1 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cf-units>=2
 cftime>=1.1.0
-isodate>=0.5.4
+isodate>=0.6.1
 jinja2>=2.7.3
 lxml>=3.2.1
 netcdf4>=1.5.7


### PR DESCRIPTION
Some builds were failing on isodate requirements due to newer setuptools not having 2to3 support.  Newer builds of isodate shouldn't have this issue.