### PR TITLE
v4 is beta and was probably mistakenly release as stable

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -37,6 +37,6 @@ jobs:
       continue-on-error: true
 
     - name: Upload to codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         files: coverage.xml


### PR DESCRIPTION
Should fix the codecov GHA. See https://github.com/ioos/compliance-checker/pull/1043 where the erroneous stable version v4 was added.