### PR TITLE
Feature: Allow custom CF url (-d)

### DIFF
--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -293,7 +293,7 @@ def download_cf_standard_name_table(version, location=None):
             url = version
             version = '"url specified"'
         else:
-            url = f"http://cfconventions.org/Data/cf-standard-names/{}/src/cf-standard-name-table.xml".format(
+            url = "http://cfconventions.org/Data/cf-standard-names/{}/src/cf-standard-name-table.xml".format(
                 version
             )
 

--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -289,7 +289,13 @@ def download_cf_standard_name_table(version, location=None):
     if version == "latest":
         url = "http://cfconventions.org/Data/cf-standard-names/current/src/cf-standard-name-table.xml"
     else:
-        url = f"http://cfconventions.org/Data/cf-standard-names/{version}/src/cf-standard-name-table.xml"
+        if version.startswith('http'):
+            url = version
+            version = '"url specified"'
+        else:
+            url = f"http://cfconventions.org/Data/cf-standard-names/{}/src/cf-standard-name-table.xml".format(
+                version
+            )
 
     r = requests.get(url, allow_redirects=True)
     r.raise_for_status()


### PR DESCRIPTION
Allow for a custom CF url for checking standards.   Allows for checking files with a custom CF xml file with proposed changes to ensure operability prior to adoption.   

Example of use:
```
$ compliance-checker -t gliderdac:3.0 -O gliderdac:no_ancillary_variables -d https://acoustics.fish.washington.edu/research/cf/cf-standard-name-table.xml gutils/rt/netcdf/unit_507_1712092237_20240402T211037Z_rt.nc
Downloading cf-standard-names table version "url specified" from: https://acoustics.fish.washington.edu/research/cf/cf-standard-name-table.xml
Running Compliance Checker on the datasets from: ['gutils/rt/netcdf/unit_507_1712092237_20240402T211037Z_rt.nc']


--------------------------------------------------------------------------------
                         IOOS Compliance Checker Report                         
                     Version 5.1.2.dev3+gc17f5f6.d20240501                      
                     Report generated 2024-05-01T06:03:43Z                      
                                 gliderdac:3.0                                  
      https://ioos.github.io/glider-dac/ngdac-netcdf-file-format-version-2      
--------------------------------------------------------------------------------
All tests passed!
```

This comes with a bug to track down: the program needs to be run twice.   Once to download the custom XML and a second time to actually use it.  So, there is actually a bug when requesting a different version of the CF standard names as well.