### PR TITLE
add NCEI downstream plugin test

### DIFF
--- a/.github/workflows/cc-plugin-ncei-test.yml
+++ b/.github/workflows/cc-plugin-ncei-test.yml
@@ -1,0 +1,37 @@
+name: NCEI Plugin Tests
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Micromamba
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-name: TEST
+        init-shell: bash
+        create-args: >-
+          python=3 pip
+          --file requirements.txt
+          --file test_requirements.txt
+          --channel conda-forge
+
+    - name: Install compliance-checker
+      shell: bash -l {0}
+      run: |
+        python -m pip install -e . --no-deps --force-reinstall
+
+    - name: cc-plugin-ncei tests
+      shell: bash -l {0}
+      run: >
+        git clone https://github.com/ioos/cc-plugin-ncei.git
+        && cd cc-plugin-ncei
+        && micromamba install --file requirements.txt --file requirements-dev.txt --channel conda-forge
+        && python -m pip install -e . --no-deps --force-reinstall
+        && python -m pytest -s -rxs -v cc_plugin_ncei


### PR DESCRIPTION
We thought that https://github.com/ioos/cc-plugin-ncei/issues/52 would break this test here but it turns out we are not testing this plugin. Maybe we don't need it anymore? Do you know why we don't have it here @benjwadams?

Anyway, the NCEI plugin has an upstream test and should pass here as well. Let's try...