### PR TITLE
Use README.md as quickintro

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The computer-readable name field controls how Results are aggregated together - 
 it is possible to *group* Results together via the name property.
 Grouped results will only add up to a single top-level entry.
 
-See the [Development](//github.com/ioos/compliance-checker/wiki/Development) wiki page for more details on implementation.
+See the [Development](https://github.com/ioos/compliance-checker/wiki/Development) wiki page for more details on implementation.
 
 ## Installation
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -165,8 +165,3 @@ texinfo_documents = [
         "Miscellaneous",
     ),
 ]
-
-linkcheck_ignore = [
-    # TODO: check again in the future
-    r"https://mmisw.org/ont/ioos/platform",  # 2023-09-05 site non-responsive
-]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,7 @@ Python tool to check your datasets against compliance standards.
    :maxdepth: 3
    :caption: Contents:
 
-   quickintro
+   readme_link
    compliance_checker_api
    faq
    development

--- a/docs/source/readme_link.md
+++ b/docs/source/readme_link.md
@@ -1,0 +1,2 @@
+```{include} ../../README.md
+```


### PR DESCRIPTION
This was already the case but we were copying-n-pasting the contents. Now we can edit the README and the quick intro section will be auto-updated.

PS: We need to convert the wiki contentes to docs and update them.