### PR TITLE
Remove assert statement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
 
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.4
+  rev: v0.4.5
   hooks:
     - id: ruff
 

--- a/compliance_checker/base.py
+++ b/compliance_checker/base.py
@@ -254,7 +254,10 @@ class Result:
         if value is None:
             self.value = None
         elif isinstance(value, tuple):
-            assert len(value) == 2, "Result value must be 2-tuple or boolean!"
+            if len(value) != 2:
+                raise ValueError(
+                    f"Result value must be 2-tuple or boolean! Got {value}",
+                )
             self.value = value
         else:
             self.value = bool(value)

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -299,7 +299,8 @@ class CheckSuite:
         the user selected names.
         """
 
-        assert len(self.checkers) > 0, "No checkers could be found."
+        if len(self.checkers) <= 0:
+            raise ValueError("No checkers could be found.")
 
         if len(checker_names) == 0:
             checker_names = list(self.checkers.keys())


### PR DESCRIPTION
Asserts are dropped when using optimizations or compilers. They should be used only in tests, not in code. For more info see https://docs.astral.sh/ruff/rules/assert/