### PR TITLE
Fix windows tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         - test_requirements.txt
 
 - repo: https://github.com/psf/black
-  rev: 24.4.2
+  rev: 24.8.0
   hooks:
   - id: black
     language_version: python3
@@ -31,12 +31,12 @@ repos:
 
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.5.0
+  rev: v0.5.7
   hooks:
     - id: ruff
 
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: 2.1.3
+  rev: 2.2.1
   hooks:
     - id: pyproject-fmt
 

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -3340,7 +3340,7 @@ class CF1_6Check(CFNCCheck):
 
             # IMPLEMENTATION CONFORMANCE 8.1 REQUIRED 1/3
             # scale_factor and add_offset same type
-            if type(add_offset) != type(scale_factor):
+            if not isinstance(add_offset, type(scale_factor)):
                 valid = False
                 reasoning.append(
                     "Attributes add_offset and scale_factor have different data type.",
@@ -3350,7 +3350,7 @@ class CF1_6Check(CFNCCheck):
             # if not the same type
             # FIXME: Check add_offset too.
 
-            elif type(scale_factor) != var.dtype.type:
+            elif not isinstance(scale_factor, var.dtype.type):
                 # Check both attributes are type float or double
                 if not isinstance(scale_factor, (float, np.floating)):
                     valid = False

--- a/compliance_checker/cf/cf_1_9.py
+++ b/compliance_checker/cf/cf_1_9.py
@@ -150,7 +150,10 @@ class CF1_9Check(CF1_8Check):
                     continue
                 appendix_a_not_recommended_attrs = []
                 for attr_name in domain_var.ncattrs():
-                    if attr_name in self.appendix_a and "D" not in self.appendix_a[attr_name]["attr_loc"]:
+                    if (
+                        attr_name in self.appendix_a
+                        and "D" not in self.appendix_a[attr_name]["attr_loc"]
+                    ):
                         appendix_a_not_recommended_attrs.append(attr_name)
 
                 if appendix_a_not_recommended_attrs:
@@ -163,10 +166,12 @@ class CF1_9Check(CF1_8Check):
                 # no errors occurred
                 domain_valid.score += 1
 
-
             # IMPLEMENTATION CONFORMANCE 5.8 REQUIRED 4/4
             if hasattr(domain_var, "cell_measures"):
-                cell_measures_var_names = regex.findall(r"\b(?:area|volume):\s+(\w+)", domain_var.cell_measures)
+                cell_measures_var_names = regex.findall(
+                    r"\b(?:area|volume):\s+(\w+)",
+                    domain_var.cell_measures,
+                )
                 # check exist
                 for var_name in cell_measures_var_names:
                     try:
@@ -174,10 +179,16 @@ class CF1_9Check(CF1_8Check):
                     except ValueError:
                         # TODO: what to do here?
                         continue
-                    domain_coord_var_names = {var_like.name for var_like in domain_coord_vars}
-                    domain_valid.assert_true(set(cell_measures_variable.dimensions).issubset(domain_coord_var_names),
-                                             "Variables named in the cell_measures attributes must have a dimensions attribute with "
-                                             "values that are a subset of the referring domain variable's dimension attribute")
+                    domain_coord_var_names = {
+                        var_like.name for var_like in domain_coord_vars
+                    }
+                    domain_valid.assert_true(
+                        set(cell_measures_variable.dimensions).issubset(
+                            domain_coord_var_names,
+                        ),
+                        "Variables named in the cell_measures attributes must have a dimensions attribute with "
+                        "values that are a subset of the referring domain variable's dimension attribute",
+                    )
 
             results.append(domain_valid.to_result())
 

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -6,7 +6,6 @@ import codecs
 import inspect
 import itertools
 import os
-import platform
 import re
 import subprocess
 import sys
@@ -893,10 +892,6 @@ class CheckSuite:
             ds_str = self.generate_dataset(ds_str)
 
         if zarr.is_zarr(ds_str):
-            if platform.system() != "Linux":
-                print(
-                    f"WARNING: {platform.system()} OS detected. NCZarr is not officially supported for your OS as of when this API was written. Your mileage may vary.",
-                )
             return Dataset(zarr.as_zarr(ds_str))
 
         if netcdf.is_netcdf(ds_str):

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -3249,7 +3249,7 @@ class TestCF1_9(BaseTestCase):
         dataset.createDimension("lat", 20)
         dataset.createDimension("depth", 20)
         domain_var.setncattr("dimensions", "lon lat depth")
-        cube = dataset.createVariable("cube", "f8", ("lon", "lat", "depth"))
+        dataset.createVariable("cube", "f8", ("lon", "lat", "depth"))
         # OK, coordinates in cell_measures are subset of coordinates of
         # referring domain variable's coordinates attribute
         results = self.cf.check_domain_variables(dataset)
@@ -3258,10 +3258,12 @@ class TestCF1_9(BaseTestCase):
         domain_var.cell_measures = "volume: cube_bad"
         dataset.createVariable("cube_bad", "f8", ("lon", "lat", "depth", "time"))
         results = self.cf.check_domain_variables(dataset)
-        self.assertTrue("Variables named in the cell_measures attributes must "
-                        "have a dimensions attribute with values that are a "
-                        "subset of the referring domain variable's dimension "
-                        "attribute" in results[0].msgs)
+        self.assertTrue(
+            "Variables named in the cell_measures attributes must "
+            "have a dimensions attribute with values that are a "
+            "subset of the referring domain variable's dimension "
+            "attribute" in results[0].msgs,
+        )
         del dataset
         dataset = MockTimeSeries()
         # domain should be dimensionless -- currently not an error in

--- a/compliance_checker/tests/test_cli.py
+++ b/compliance_checker/tests/test_cli.py
@@ -242,7 +242,7 @@ class TestCLI:
         reason="NCZarr support was not available until netCDF version 4.8.0. Please upgrade to the latest libnetcdf version to test this functionality",
     )
     @pytest.mark.skipif(
-        subprocess.check_output([ncconfig, "--has-nczarr"]) != b"yes\n",
+        subprocess.check_output(ncconfig + ["--has-nczarr"]) != b"yes\n",
         reason="NCZarr is not officially supported for your OS as of when this API was written",
     )
     @pytest.mark.skipif(

--- a/compliance_checker/tests/test_cli.py
+++ b/compliance_checker/tests/test_cli.py
@@ -20,8 +20,10 @@ from compliance_checker.runner import CheckSuite, ComplianceChecker
 
 from .conftest import datadir, static_files
 
-if platform.system() == "Windows":
-    ncconfig = ["bash", f"{os.environ['CONDA_PREFIX']}\\Library\\bin\\nc-config"]
+on_windows = platform.system() == "Windows"
+
+if on_windows:
+    ncconfig = ["sh", f"{os.environ['CONDA_PREFIX']}\\Library\\bin\\nc-config"]
 else:
     ncconfig = ["nc-config"]
 
@@ -236,18 +238,9 @@ class TestCLI:
             < 8.0
         )
 
-    # TODO uncomment the third parameter once S3 support is working
-    @pytest.mark.skipif(
-        _check_libnetcdf_version(),
-        reason="NCZarr support was not available until netCDF version 4.8.0. Please upgrade to the latest libnetcdf version to test this functionality",
-    )
     @pytest.mark.skipif(
         subprocess.check_output(ncconfig + ["--has-nczarr"]) != b"yes\n",
-        reason="NCZarr is not officially supported for your OS as of when this API was written",
-    )
-    @pytest.mark.skipif(
-        subprocess.check_output(["nc-config", "--has-nczarr"]) != b"yes\n",
-        reason="NCZarr support was not built with this netCDF version",
+        reason="NCZarr is not available.",
     )
     @pytest.mark.parametrize(
         "zarr_url",
@@ -256,7 +249,12 @@ class TestCLI:
             str(datadir / "zip.zarr"),
             # "s3://hrrrzarr/sfc/20210408/20210408_10z_anl.zarr#mode=nczarr,s3"
         ],
-        ids=["local_file", "zip_file"],  # ,'s3_url'
+        ids=[
+            "local_file",
+            "zip_file",
+            # TODO uncomment once S3 support is working.
+            # "s3_url",
+        ],
     )
     def test_nczarr_pass_through(self, zarr_url):
         """


### PR DESCRIPTION
This should fix the detection of nczarr on Windows but will work only on CIs with bash and conda. I guess that is our default environment for developing on Windows anyway. I'm looking into upstream a non-bash script to libnetcdf so we can drop these workarounds.

Closes https://github.com/ioos/compliance-checker/pull/1102