### PR TITLE
Add Python 3.13 to the test matrix

### DIFF
--- a/.github/workflows/default-tests.yml
+++ b/.github/workflows/default-tests.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        os: [ windows-latest, ubuntu-latest, macos-latest ]
       fail-fast: false
     defaults:
       run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,12 +31,12 @@ repos:
 
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.6.9
+  rev: v0.7.0
   hooks:
     - id: ruff
 
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: 2.2.4
+  rev: 2.4.3
   hooks:
     - id: pyproject-fmt
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering",
 ]
 dynamic = [


### PR DESCRIPTION
Also dropping Python 3.8 b/c it already reached EOL.