### PR TITLE
Minimum Python support 3.10

### DIFF
--- a/.github/workflows/default-tests.yml
+++ b/.github/workflows/default-tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
         os: [ windows-latest, ubuntu-latest, macos-latest ]
       fail-fast: false
     defaults:

--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -1,11 +1,11 @@
 import itertools
 import os
 import sys
+from importlib.resources import files
 from pkgutil import get_data
 
 import requests
 from cf_units import Unit
-from importlib_resources import files
 from lxml import etree
 from netCDF4 import Dataset
 

--- a/compliance_checker/cfutil.py
+++ b/compliance_checker/cfutil.py
@@ -7,9 +7,9 @@ import re
 import warnings
 from collections import defaultdict
 from functools import lru_cache, partial
+from importlib.resources import files
 
 from cf_units import Unit
-from importlib_resources import files
 
 _UNITLESS_DB = None
 _SEA_NAMES = None

--- a/compliance_checker/suite.py
+++ b/compliance_checker/suite.py
@@ -13,11 +13,11 @@ import textwrap
 import warnings
 from collections import defaultdict
 from datetime import datetime, timezone
+from importlib.metadata import entry_points
 from operator import itemgetter
 from pathlib import Path
 from urllib.parse import urlparse
 
-import importlib_metadata
 import requests
 from lxml import etree as ET
 from netCDF4 import Dataset
@@ -73,7 +73,7 @@ class CheckSuite:
         """
 
         if not hasattr(cls, "suite_generators"):
-            gens = importlib_metadata.entry_points(
+            gens = entry_points(
                 group="compliance_checker.generators",
             )
             cls.suite_generators = [x.load() for x in gens]
@@ -139,7 +139,7 @@ class CheckSuite:
         base classes.
         """
         cls._load_checkers(
-            importlib_metadata.entry_points(group="compliance_checker.suites"),
+            entry_points(group="compliance_checker.suites"),
         )
 
     @classmethod

--- a/compliance_checker/tests/conftest.py
+++ b/compliance_checker/tests/conftest.py
@@ -1,9 +1,9 @@
 import os
 import subprocess
+from importlib.resources import files
 from itertools import chain
 
 import pytest
-from importlib_resources import files
 from netCDF4 import Dataset
 
 from compliance_checker.cf import util

--- a/compliance_checker/tests/resources.py
+++ b/compliance_checker/tests/resources.py
@@ -1,6 +1,5 @@
 import subprocess
-
-from importlib_resources import files
+from importlib.resources import files
 
 
 def get_filename(path):

--- a/compliance_checker/tests/test_suite.py
+++ b/compliance_checker/tests/test_suite.py
@@ -1,9 +1,9 @@
 import os
 import unittest
+from importlib.resources import files
 from pathlib import Path
 
 import numpy as np
-from importlib_resources import files
 
 from compliance_checker.acdd import ACDDBaseCheck
 from compliance_checker.base import BaseCheck, GenericFile, Result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
   { name = "Luke Campbell" },
   { name = "Filipe Fernandes" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -28,8 +28,6 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 cf-units>=2
 cftime>=1.1.0
-importlib-metadata
-importlib-resources
 isodate>=0.6.1
 jinja2>=2.7.3
 lxml>=3.2.1


### PR DESCRIPTION
Python 3.8 reached EOL and while 3.9 will only reach EOL 2025-10, pyudunits2 is py310 only and we should move away from the compiled udunits2 extension.

@benjwadams let me know what you think. Once this one is merged I'm also planning on activating pyupgrade and ruff format and slowly update the code here.