### PR TITLE
FIX: Error in util.py when no attributes found in StandardNameTable

### DIFF
--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -1,18 +1,16 @@
 import itertools
 import os
+import posixpath
 import sys
+from functools import lru_cache
 from importlib.resources import files
 from pkgutil import get_data
+from typing import Union
 
-from functools import lru_cache
 import requests
 from cf_units import Unit
 from lxml import etree
-from netCDF4 import Variable, Dimension, Dataset, Group
-
-import posixpath
-
-from typing import Tuple, Union
+from netCDF4 import Dataset, Dimension, Group, Variable
 
 from compliance_checker.cfutil import units_convertible
 
@@ -410,7 +408,7 @@ def string_from_var_type(variable):
         )
 
 
-def get_possible_label_variable_dimensions(variable: Variable) -> Tuple[int, ...]:
+def get_possible_label_variable_dimensions(variable: Variable) -> tuple[int, ...]:
     """
     Return dimensions if non-char variable, or return variable dimensions
     without trailing dimension if char variable, treating it as a label variable.
@@ -420,13 +418,15 @@ def get_possible_label_variable_dimensions(variable: Variable) -> Tuple[int, ...
     return variable.dimensions
 
 
-@lru_cache()
-def maybe_lateral_reference_variable_or_dimension(group: Union[Group, Dataset],
-                                                  name: str,
-                                                  reference_type: Union[Variable, Dimension]):
+@lru_cache
+def maybe_lateral_reference_variable_or_dimension(
+    group: Union[Group, Dataset],
+    name: str,
+    reference_type: Union[Variable, Dimension],
+):
 
     def can_lateral_search(name):
-        return (not name.startswith(".") and posixpath.split(name)[0] == "")
+        return not name.startswith(".") and posixpath.split(name)[0] == ""
 
     if reference_type == "variable":
         # first try to fetch any
@@ -441,12 +441,13 @@ def maybe_lateral_reference_variable_or_dimension(group: Union[Group, Dataset],
 
         # alphanumeric string by itself, not a relative or absolute
         # search by proximity
-        if (posixpath.split(name)[0] == "" and
-            not (name.startswith(".") or name.startswith("/"))):
+        if posixpath.split(name)[0] == "" and not (
+            name.startswith(".") or name.startswith("/")
+        ):
             group_traverse = group
             while group_traverse.parent:
                 group_traverse = group_traverse.parent
-                check_target = posixpath.join(group_traverse.path, name)
+                # check_target = posixpath.join(group_traverse.path, name)
                 try:
                     maybe_var = group_traverse[name]
                 except IndexError:
@@ -459,7 +460,6 @@ def maybe_lateral_reference_variable_or_dimension(group: Union[Group, Dataset],
 
             # can't find path relative to current group or absolute path
             # perform lateral search if we aren't in the root group
-
 
 
 def reference_attr_variables(

--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -210,7 +210,7 @@ class StandardNameTable:
             elif required and len(vals) == 0:
                 raise Exception(f"Required attr ({attrname}) not found")
 
-            return vals[0].text
+            return vals[0].text if len(vals) > 0 else None
 
     def __init__(self, cached_location=None):
         if cached_location:

--- a/compliance_checker/runner.py
+++ b/compliance_checker/runner.py
@@ -148,12 +148,21 @@ class ComplianceChecker:
         """
 
         for ds, score_groups in score_dict.items():
-            for checker, (groups, errors) in score_groups.items():
+            for checker, (groups, _errors) in score_groups.items():
                 score_list, points, out_of = cs.standard_output(
-                    ds, limit, checker, groups)
+                    ds,
+                    limit,
+                    checker,
+                    groups,
+                )
                 # send list of grouped result objects to stdout & reasoning_routine
                 cs.standard_output_generation(
-                    groups, limit, points, out_of, check=checker)
+                    groups,
+                    limit,
+                    points,
+                    out_of,
+                    check=checker,
+                )
         return groups
 
     @classmethod


### PR DESCRIPTION
This fixes issue #1132 

### Error was being raised when no attributes were found of the ```entrynode``` in the _get() of ```StandardNameTable```

### Fix (At line 211):
Returns None if no attributes found

Please review @benjwadams 

