### PR TITLE
Filter specific warnings to find hidden bugs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
 
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.4
+  rev: v0.9.6
   hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ markers = [
   "slowtest: marks slow tests (deselect with '-m \"not slowtest\"')",
 ]
 filterwarnings = [
-  "error:::compliance-checker.*",
-  "ignore::UserWarning",
-  "ignore::RuntimeWarning",
+  "error",
+  "ignore:this date/calendar/year zero convention is not supported by CF", # CFtime warning, probably harmless here?
+  "ignore:Received exception when making HEAD request to",                 # In compliance_checker/protocols/netcdf.py::is_remote_netcdfWe can still tell if it is remote without the handshake.
 ]


### PR DESCRIPTION
We found `ResourceWarning: unclosed database` in Python 3.13 and `ResourceWarning: unclosed file` on Windows. These are not a high fix priority b/c they are related to the tests mocked netCDF and do not affect compliance-checker per se.