### PR TITLE
Add geospatial_vertical_positive value check for ACDD

### DIFF
--- a/compliance_checker/acdd.py
+++ b/compliance_checker/acdd.py
@@ -694,7 +694,7 @@ class ACDD1_1Check(ACDDNCCheck):
                 "publisher_name",  # publisher,dataCenter
                 "publisher_url",  # publisher
                 "publisher_email",  # publisher
-                "geospatial_vertical_positive",
+                ("geospatial_vertical_positive", ["up", "down"])
             ],
         )
 
@@ -710,7 +710,7 @@ class ACDD1_3Check(ACDDNCCheck):
 
         self.rec_atts.extend(
             [
-                "geospatial_vertical_positive",
+                ("geospatial_vertical_positive", ["up", "down"]),
                 "geospatial_bounds_crs",
                 "geospatial_bounds_vertical_crs",
                 "publisher_name",  # publisher,dataCenter

--- a/compliance_checker/acdd.py
+++ b/compliance_checker/acdd.py
@@ -694,7 +694,7 @@ class ACDD1_1Check(ACDDNCCheck):
                 "publisher_name",  # publisher,dataCenter
                 "publisher_url",  # publisher
                 "publisher_email",  # publisher
-                ("geospatial_vertical_positive", ["up", "down"])
+                ("geospatial_vertical_positive", ["up", "down"]),
             ],
         )
 


### PR DESCRIPTION
Adds a check for either "up" or "down" on the attribute "geospatial_vertical_positive" for the ACDD checker.