### PR TITLE
Rudimentary check for geometry instance dimension

### DIFF
--- a/compliance_checker/cf/cf_1_8.py
+++ b/compliance_checker/cf/cf_1_8.py
@@ -295,6 +295,7 @@ class CF1_8Check(CF1_7Check):
                 results.append(geom_valid.to_result())
                 continue
             # check geometry
+            geom_valid.out_of += 1
             messages = geometry.check_geometry()
             if not messages:
                 geom_valid.score += 1

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -2846,6 +2846,16 @@ class TestCF1_8(BaseTestCase):
         y[:] = np.array([30, 35, 21])
         return dataset
 
+    def test_geometry_dimension(self, geometry_ds):
+        geometry_ds.createDimension("false_x", 2)
+        false_x = geometry_ds.createVariable("false_x", "i4", ("false_x",))
+        false_x.geometry = "geometry"
+        results = self.cf.check_geometry(geometry_ds)
+        assert (
+            "Geometry containing variable false_x needs at least one "
+            "instance dimension" in results[0].msgs
+        )
+
     # TEST CONFORMANCE 7.5 REQUIRED 10/20
     @pytest.mark.parametrize(
         "geom_grid_mapping,geom_coordinates",


### PR DESCRIPTION
Requirement states "One of the dimensions of the data variable with geometry must be the number of geometries to which the data applies." Currently only checks that the number of non-coordinate variable dimensions is greater than one.