### PR TITLE
fix report of multiple tests for `json_new` format

### DIFF
--- a/compliance_checker/runner.py
+++ b/compliance_checker/runner.py
@@ -229,9 +229,9 @@ class ComplianceChecker:
                     )
         elif output_type == "json_new":
             for ds, score_groups in score_dict.items():
+                results[ds] = {}
                 for checker, rpair in score_groups.items():
                     groups, errors = rpair
-                    results[ds] = {}
                     results[ds][checker] = cs.dict_output(checker, groups, ds, limit)
         json_results = json.dumps(results, indent=2, ensure_ascii=False)
 


### PR DESCRIPTION
This is just a tiny bugfix. It seems that `json_new` format does not write outputs of multiple tests (the initial dict is always overwritten).