### PR TITLE
added functionality to satisfy Section 2.7 Groups

### DIFF
--- a/compliance_checker/cf/cf_1_8.py
+++ b/compliance_checker/cf/cf_1_8.py
@@ -111,6 +111,34 @@ class CF1_8Check(CF1_7Check):
 
         return results
 
+    def check_invalid_same_named_dimension_across_groups(self, ds):
+        """
+        Section 2 NetCDF Files and Components
+        Section 2.7. Groups
+        Section 2.7.1. Scope
+        
+        "If any dimension of an out-of-group variable has the same name as a dimension of 
+        the referring variable, the two must be the same dimension (i.e. they must have 
+        the same netCDF dimension ID)."
+        """
+        
+        results = []
+
+        invalid_same_named_dimension_across_groups = TestCtx(BaseCheck.HIGH, self.section_titles["2.7.1"])
+        
+        # Using the group B dimension to match a variable from group A.
+        # This is logically wrong: NetCDF allows it, but the dimensions are different objects.
+        # This may not throw during creation, so we simulate an access/mismatch
+        invalid_same_named_dimension_across_groups.assert_true(
+            ds.groups["A"].dimensions["time"] is
+            ds.groups["B"].dimensions["time"],
+            "Dimensions with the same name must be the same object (ID).",
+            )
+
+        results.append(invalid_same_named_dimension_across_groups.to_result())
+
+        return results
+    
     def check_geometry(self, ds: Dataset):
         """Runs any necessary checks for geometry well-formedness
         :param netCDF4.Dataset ds: An open netCDF dataset

--- a/compliance_checker/cf/cf_base.py
+++ b/compliance_checker/cf/cf_base.py
@@ -47,6 +47,7 @@ class CFBaseCheck(BaseCheck):
             "2.5": "§2.5 Variables",
             "2.6": "§2.6 Attributes",
             "2.6.3": "§2.6.3 External Variables",
+            "2.7.1": "§2.7.1. Scope",
             "3.1": "§3.1 Units",
             "3.2": "§3.2 Long Name",
             "3.3": "§3.3 Standard Name",

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -2810,6 +2810,24 @@ class TestCF1_8(BaseTestCase):
         }
         assert bad_messages == set(results[0].msgs)
 
+    def test_check_invalid_same_named_dimension_across_groups(self):
+        dataset = MockTimeSeries()
+        # TEST CONFORMANCE 2.7.1 Scope REQUIRED 2/4
+        # Group A defines its own dimension
+        group_a = dataset.createGroup("A")
+        group_a.createDimension("time", 10)
+        var_a = group_a.createVariable("temperature", "f4", ("time",))
+
+        # Group B defines a separate dimension with the same name
+        group_b = dataset.createGroup("B")
+        group_b.createDimension("time", 10)
+        
+        results = self.cf.check_invalid_same_named_dimension_across_groups(dataset)
+
+        result_dict = {result.name: result for result in results}
+        result = result_dict["§2.7.1. Scope"]
+        assert result.msgs == ["Dimensions with the same name must be the same object (ID)."]
+    
     def test_point_geometry_simple(self):
         dataset = MockTimeSeries()
         dataset.createDimension("instance", 1)


### PR DESCRIPTION
defined a function in cf_1_8.py: 
check_invalid_same_named_dimension_across_groups()

added a section tilte to cf_base.py:
"2.7.1": "§2.7.1. Scope",

added a test function in test_cf.py:
test_check_invalid_same_named_dimension_across_groups()