### PR TITLE
Make NaN a valid FillValue

### DIFF
--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -420,7 +420,10 @@ class CF1_6Check(CFNCCheck):
 
             if hasattr(variable, "_FillValue") and hasattr(variable, "missing_value"):
                 total = total + 1
-                if variable._FillValue != variable.missing_value:
+                if not (
+                    variable._FillValue == variable.missing_value or
+                    (np.isnan(variable._FillValue) and np.isnan(variable.missing_value))
+                ):
                     fails.append(
                         f"For the variable {variable.name} the missing_value must be equal to the _FillValue",
                     )

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -421,8 +421,11 @@ class CF1_6Check(CFNCCheck):
             if hasattr(variable, "_FillValue") and hasattr(variable, "missing_value"):
                 total = total + 1
                 if not (
-                    variable._FillValue == variable.missing_value or
-                    (np.isnan(variable._FillValue) and np.isnan(variable.missing_value))
+                    variable._FillValue == variable.missing_value
+                    or (
+                        np.isnan(variable._FillValue)
+                        and np.isnan(variable.missing_value)
+                    )
                 ):
                     fails.append(
                         f"For the variable {variable.name} the missing_value must be equal to the _FillValue",

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -369,6 +369,12 @@ class TestCF1_6(BaseTestCase):
         dataset.variables["b"][1] = 2
         dataset.variables["b"].setncattr("missing_value", [9999.9])
 
+        # Case of _FillValue and missing_value are equal but set to NaN
+        dataset.createVariable("c", "d", ("time",), fill_value=float("nan"))
+        dataset.variables["c"][0] = 1
+        dataset.variables["c"][1] = 2
+        dataset.variables["c"].setncattr("missing_value", [float("nan")])
+
         result = self.cf.check_fill_value_equal_missing_value(dataset)
 
         # check if the test fails when when variable "a" is checked.


### PR DESCRIPTION
We have data where `nan` is used as the FillValue and is marked as an error by the compliance checker.