### PR TITLE
remove nargs for criteria in argparse

### DIFF
--- a/cchecker.py
+++ b/cchecker.py
@@ -72,7 +72,6 @@ def main():
             "Define the criteria for the checks. "
             "Either Strict, Normal, or Lenient.  Defaults to Normal."
         ),
-        nargs="?",
         default="normal",
         choices=["lenient", "normal", "strict"],
     )


### PR DESCRIPTION
Rather insignificant bugfix: I accidentally let the compliance-checker run with `-c` without setting an actual criteria-level, which resulted in a crash with a rather ugly exception instead of pointing out the actual usage.

I am not sure whether there is some reasoning I don't understand, but having `nargs="?"` set for `criteria` results in `criteria=None`, ignoring the default, when starting the compliance checker like I did. I couldn't find any good reason why `nargs="?"` should be used here, so I removed it.