### PR TITLE
3.5: Fix dealing with wrong type in flags

### DIFF
--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -420,13 +420,7 @@ class CF1_6Check(CFNCCheck):
 
             if hasattr(variable, "_FillValue") and hasattr(variable, "missing_value"):
                 total = total + 1
-                if not (
-                    variable._FillValue == variable.missing_value
-                    or (
-                        np.isnan(variable._FillValue)
-                        and np.isnan(variable.missing_value)
-                    )
-                ):
+                if variable._FillValue != variable.missing_value:
                     fails.append(
                         f"For the variable {variable.name} the missing_value must be equal to the _FillValue",
                     )
@@ -1185,7 +1179,13 @@ class CF1_6Check(CFNCCheck):
                 # IMPLEMENTATION CONFORMANCE 3.5 RECOMMENDED 1/1
                 # If shapes aren't equal, we can't do proper elementwise
                 # comparison
-                if vals_arr.size != masks_arr.size:
+                if (
+                    vals_arr.size != masks_arr.size
+                    or not (
+                        np.issubdtype(vals_arr.dtype, np.integer)
+                        and np.issubdtype(masks_arr.dtype, np.integer)
+                    )
+                ):
                     allv = False
                 else:
                     allv = np.all(vals_arr & masks_arr == vals_arr)
@@ -1235,9 +1235,10 @@ class CF1_6Check(CFNCCheck):
 
         # IMPLEMENTATION CONFORMANCE 3.5 REQUIRED 1/8
         # the data type for flag_values should be the same as the variable
+        flag_values_type = flag_values.dtype.type if hasattr(flag_values, "dtype") else type(flag_values)
         valid_values.assert_true(
-            variable.dtype.type == flag_values.dtype.type,
-            f"flag_values ({flag_values.dtype.type}) must be the same data type as {name} ({variable.dtype.type})"
+            variable.dtype.type == flag_values_type,
+            f"flag_values ({flag_values_type}) must be the same data type as {name} ({variable.dtype.type})"
             "",
         )
 
@@ -1272,9 +1273,10 @@ class CF1_6Check(CFNCCheck):
 
         valid_masks = TestCtx(BaseCheck.HIGH, self.section_titles["3.5"])
 
+        flag_masks_type = flag_masks.dtype.type if hasattr(flag_masks, "dtype") else type(flag_masks)
         valid_masks.assert_true(
-            variable.dtype.type == flag_masks.dtype.type,
-            f"flag_masks ({flag_masks.dtype.type}) must be the same data type as {name} ({variable.dtype.type})"
+            variable.dtype.type == flag_masks_type,
+            f"flag_masks ({flag_masks_type}) must be the same data type as {name} ({variable.dtype.type})"
             "",
         )
 

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -369,12 +369,6 @@ class TestCF1_6(BaseTestCase):
         dataset.variables["b"][1] = 2
         dataset.variables["b"].setncattr("missing_value", [9999.9])
 
-        # Case of _FillValue and missing_value are equal but set to NaN
-        dataset.createVariable("c", "d", ("time",), fill_value=float("nan"))
-        dataset.variables["c"][0] = 1
-        dataset.variables["c"][1] = 2
-        dataset.variables["c"].setncattr("missing_value", [float("nan")])
-
         result = self.cf.check_fill_value_equal_missing_value(dataset)
 
         # check if the test fails when when variable "a" is checked.
@@ -866,6 +860,9 @@ class TestCF1_6(BaseTestCase):
         # Test with single element.  Will fail, but should not throw exception.
         dataset.variables["conductivity_qc"].flag_values = np.array([1], dtype=np.int8)
         results = self.cf.check_flags(dataset)
+        # Test with wrong type.  Will fail, but should not throw exception.
+        dataset.variables["conductivity_qc"].flag_values = "[1 2]"
+        results = self.cf.check_flags(dataset)
 
     def test_check_flag_masks(self):
         dataset = self.load_dataset(STATIC_FILES["ghrsst"])
@@ -891,6 +888,14 @@ class TestCF1_6(BaseTestCase):
         assert (
             "flag_masks for variable flags must not contain zero as an "
             "element" in messages
+        )
+        # test wrong type for flag_masks
+        flags_var.flag_masks = "[0 1]"
+        results = self.cf.check_flags(dataset)
+        score, out_of, messages = get_results(results)
+        assert (
+            "flag_masks (<class 'str'>) must be the same data type as "
+            "flags (<class 'numpy.float64'>)" in messages
         )
         # IMPLEMENTATION 3.5 REQUIRED 1/1
         flags_var.flag_masks = np.array([1], dtype="i2")


### PR DESCRIPTION
One of our users provided data which use strings instead of arrays as the datatype for flag values. This caused a crash of the compliance-checker. This PR aims to avoid the crash.

```
 	byte A4O_flag_bright(lat, lon) ; 
 		A4O_flag_bright:flag_meanings = "A4O_flag_bright" ; 
 		A4O_flag_bright:flag_values = "0U 1U" ; 
 		A4O_flag_bright:flag_masks = "1U" ; 
 		A4O_flag_bright:long_name = "Level_2 bright mask for TOA reflectance (at 490) > 0.3, that includes possible clouds and sea ice" ; 
```