### PR TITLE
Avoid comparing cftime objects due to poor performace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
 
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.12
+  rev: v0.12.0
   hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -1984,9 +1984,10 @@ class CF1_6Check(CFNCCheck):
 
             # Comparing cftime objects is awfully slow. Converting them toordinal makes this a bit faster.
             # https://github.com/ioos/compliance-checker/issues/1211
-            _times = np.array([time.toordinal() for time in times])
-            crossover_1582 = np.any(_times < crossover_date.toordinal()) and np.any(
-                _times >= crossover_date.toordinal(),
+            _times = np.array([time.toordinal(fractional=True) for time in times])
+            _crossover_date = crossover_date.toordinal(fractional=True)
+            crossover_1582 = np.any(_times < _crossover_date) and np.any(
+                _times >= _crossover_date,
             )
             if not crossover_1582:
                 reasoning = (

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -1982,8 +1982,11 @@ class CF1_6Check(CFNCCheck):
                     ],
                 )
 
-            crossover_1582 = np.any(times < crossover_date) and np.any(
-                times >= crossover_date,
+            # Comparing cftime objects is awfully slow. Converting them toordinal makes this a bit faster.
+            # https://github.com/ioos/compliance-checker/issues/1211
+            _times = np.array([time.toordinal() for time in times])
+            crossover_1582 = np.any(_times < crossover_date.toordinal()) and np.any(
+                _times >= crossover_date.toordinal(),
             )
             if not crossover_1582:
                 reasoning = (

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -1954,16 +1954,8 @@ class CF1_6Check(CFNCCheck):
             Check that the time variable does not cross the date
             1582-10-15 when standard or gregorian calendars are used
             """
-            # WARNING: might fail here if months_since are used and suppress
-            #          usual warning
-            try:
-                cftime.num2date(
-                    time_var[:].compressed(),
-                    time_var.units,
-                    has_year_zero=True,
-                )
-                time_values = time_var[:]
-            except ValueError:
+            # Short-circuit if using months/years.
+            if any(unit in time_var.units for unit in ("months", "years")):
                 return Result(
                     BaseCheck.LOW,
                     False,
@@ -1972,6 +1964,7 @@ class CF1_6Check(CFNCCheck):
                         "Miscellaneous failure when attempting to calculate crossover, possible malformed date",
                     ],
                 )
+            time_values = time_var[:]
 
             # IMPLEMENTATION CONFORMANCE 4.4.1 RECOMMENDED 2/2
             # Only get non-nan/FillValue times, as these are the only things


### PR DESCRIPTION
Closes #1211

@benjwadams do you mind taking a look at this one? While it passes all the tests, dealing with dates is always quite complex and error prone.

@mphemming thanks for the detailed issue in #1211. Can you test this branch against your data and see if it helps?

xref.: https://github.com/Unidata/cftime/issues/365