### PR TITLE
Fix bug in html text parsing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         - test_requirements.txt
 
 - repo: https://github.com/psf/black
-  rev: 25.1.0
+  rev: 25.9.0
   hooks:
   - id: black
     language_version: python3
@@ -30,13 +30,13 @@ repos:
 
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.12
+  rev: v0.13.3
   hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]
 
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: v2.6.0
+  rev: v2.7.0
   hooks:
     - id: pyproject-fmt
 
@@ -56,7 +56,7 @@ repos:
           )$
 
 - repo: https://github.com/woodruffw/zizmor-pre-commit
-  rev: v1.12.1
+  rev: v1.14.2
   hooks:
     - id: zizmor
 

--- a/compliance_checker/cf/cf_1_8.py
+++ b/compliance_checker/cf/cf_1_8.py
@@ -17,7 +17,6 @@ from collections import defaultdict
 
 import numpy as np
 import requests
-from lxml import etree
 from netCDF4 import Dataset
 from shapely.geometry import Polygon
 
@@ -869,8 +868,8 @@ class CF1_8Check(CF1_7Check):
                 # 400 error code indicates something is malformed on client's
                 # end
                 if response.status_code == 400:
-                    tree = etree.HTML(response.text)
-                    problem_text = tree.find("./body/p").text
+                    pattern = re.compile(r"<.*?>")
+                    problem_text = pattern.sub(" ", response.text)
                     messages.append(
                         "http://lsid.info returned an error message "
                         f"for submitted LSID string '{lsid_str}': "


### PR DESCRIPTION
#1246 is failing b/c the HTML page we are parsing to get the error changed. We could use `beautifulsoup4` here instead, b/c it is quite robust when parsing broken HTML, but I do not want to add another dependency. The solution just strips all HTML tags and adds that to the bottom of the mensagem. It can be a bit confusing, but it is what the original message upstream is.