### PR TITLE
Fix time_coverage_extents check for non-standard calendars

### DIFF
--- a/compliance_checker/acdd.py
+++ b/compliance_checker/acdd.py
@@ -13,7 +13,6 @@ import pendulum
 from cftime import num2date
 from pygeoif import from_wkt
 
-
 import compliance_checker.cf.util as cfutil
 from compliance_checker.base import (
     BaseCheck,
@@ -614,11 +613,11 @@ class ACDDBaseCheck(BaseCheck):
             # we need to use num2date and extract datetime components
             # to create pendulum datetime objects
             calendar = getattr(ds.variables[timevar], "calendar", "standard")
-            
+
             cftime_obj0 = num2date(
                 ds.variables[timevar][0],
                 ds.variables[timevar].units,
-                calendar=calendar
+                calendar=calendar,
             )
             time0 = pendulum.datetime(
                 cftime_obj0.year,
@@ -627,13 +626,13 @@ class ACDDBaseCheck(BaseCheck):
                 cftime_obj0.hour,
                 cftime_obj0.minute,
                 cftime_obj0.second,
-                tz='UTC'
+                tz="UTC",
             )
-            
+
             cftime_obj1 = num2date(
                 ds.variables[timevar][-1],
                 ds.variables[timevar].units,
-                calendar=calendar
+                calendar=calendar,
             )
             time1 = pendulum.datetime(
                 cftime_obj1.year,
@@ -642,7 +641,7 @@ class ACDDBaseCheck(BaseCheck):
                 cftime_obj1.hour,
                 cftime_obj1.minute,
                 cftime_obj1.second,
-                tz='UTC'
+                tz="UTC",
             )
         except ValueError:
             return Result(


### PR DESCRIPTION
# Fix time_coverage_extents check for non-standard calendars

Fixes #1249 

## Issue

Time coverage extent validation fails when using non-standard calendars (e.g., `all_leap`, `noleap`, `360_day`) in CF-compliant datasets.

## Root Cause

The current implementation uses `num2pydate()`, which cannot handle non-standard calendars defined in the CF conventions, causing validation to fail for datasets using these calendar types.

## Fix

- Replaced `num2pydate()` with `num2date()` to support all CF calendar types
- Implemented component-wise conversion from cftime objects to pendulum datetime objects
- Extracts year, month, day, hour, minute, and second components from cftime objects
- Constructs pendulum datetime objects with explicit UTC timezone to maintain timezone awareness
- Maintains backward compatibility with standard Gregorian calendars

## Testing

Validated with both standard and `all_leap` calendars. Both configurations now pass validation successfully.

## Result

Datasets using any CF-compliant calendar type can now be properly validated while maintaining existing functionality for standard calendars.
