### PR TITLE
Use cf-units ABI3 wheel here

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  # v6.1.0
       with:
-        python-version: "3.13"
+        python-version: "3.x"
 
     - name: Install build tools
       run: |


### PR DESCRIPTION
We can use latest Python here now. In fact we should to ensure that CC is working with the cf-units ABI3 wheel.