### PR TITLE
Slim test matrix

### DIFF
--- a/.github/workflows/default-tests.yml
+++ b/.github/workflows/default-tests.yml
@@ -10,12 +10,16 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        os: [ windows-latest, ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
         cf_units: [ false ]
         include:
-          - python-version: "3.10"
-            os: "ubuntu-latest"
+          - python-version: "3.14"
+            os: ubuntu-latest
             cf_units: true
+          - os: windows-latest
+            python-version: "3.14"
+          - os: macos-latest
+            python-version: "3.14"
       fail-fast: false
     defaults:
       run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,13 +30,13 @@ repos:
 
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.14.14
+  rev: v0.15.0
   hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]
 
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: v2.12.1
+  rev: v2.15.3
   hooks:
     - id: pyproject-fmt
 

--- a/compliance_checker/tests/test_protocols.py
+++ b/compliance_checker/tests/test_protocols.py
@@ -35,13 +35,15 @@ def test_netcdf_content_type(cs):
 
 def test_erddap(cs):
     """
-    Tests that a connection can be made to ERDDAP's GridDAP
+    Tests that a connection can be made to ERDDAP's OPeNDAP GridDAP.
     """
     url = "https://www.neracoos.org/erddap/griddap/WW3_EastCoast_latest"
     ds = cs.load_dataset(url)
     assert ds is not None
 
 
+# This URL is unresponsive.
+@pytest.mark.xfail
 def test_hyrax(cs):
     """
     Tests that a connection can be made to Hyrax
@@ -49,9 +51,6 @@ def test_hyrax(cs):
     NOTE: This test creates a VCR file that is larger than GH's limit.
     We are not recording.
     """
-    # Returns: error 405
-    # url = "http://test.opendap.org:8080/opendap/ioos/mday_joinExist.ncml"
-    # More direct file
     url = "http://test.opendap.org:8080/opendap/ioos/mday_joinExist.ncml.dap.nc4"
     ds = cs.load_dataset(url)
     assert ds is not None
@@ -64,8 +63,6 @@ def test_thredds(cs):
     NOTE: This test creates a VCR file that is larger than GH's limit.
     We are not recording.
     """
-    # Returns: error 400
-    # url = "http://thredds.ucar.edu/thredds/dodsC/grib/NCEP/GFS/Global_0p25deg_ana/TP"
     # Use a smaller dataset
     url = "https://thredds.ucar.edu/thredds/ncss/grid/grib/NCEP/GFS/Global_0p25deg_ana/TP?var=Temperature_altitude_above_msl&accept=netcdf3"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
   "shapely>=1.7.1",
   "validators>=0.14.2",
 ]
-
 urls.documentation = "https://ioos.github.io/compliance-checker"
 urls.homepage = "https://compliance.ioos.us/index.html"
 urls.repository = "https://github.com/ioos/compliance-checker"
@@ -87,14 +86,10 @@ include-package-data = true
 script-files = [
   "cchecker.py",
 ]
-
-[tool.setuptools.dynamic]
-dependencies = { file = [
+dynamic.dependencies = { file = [
   "requirements.txt",
 ] }
-
-[tool.setuptools.package-data]
-compliance_checker = [
+package-data.compliance_checker = [
   "data/*.xml",
   "tests/data/*.nc",
   "tests/data/*.cdl",
@@ -110,11 +105,9 @@ tag_regex = "^(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$"
 [tool.ruff]
 target-version = "py310"
 line-length = 200
-
 exclude = [
   "compliance_checker/cf/cf.py",
 ]
-
 lint.select = [
   "A",  # flake8-builtins
   "B",  # flake8-bugbear
@@ -128,10 +121,9 @@ lint.select = [
 lint.ignore = [
   "E501",
 ]
-
 lint.per-file-ignores."compliance_checker/cf/appendix_f.py" = [
   "B033",
-] # ignore duplicates items in the set
+]  # ignore duplicates items in the set
 lint.per-file-ignores."compliance_checker/cfutil.py" = [
   "B028",
 ]
@@ -140,12 +132,12 @@ lint.per-file-ignores."docs/source/conf.py" = [
   "E402",
 ]
 
-[tool.pytest.ini_options]
-markers = [
+[tool.pytest]
+ini_options.markers = [
   "integration: marks integration tests (deselect with '-m \"not integration\"')",
   "slowtest: marks slow tests (deselect with '-m \"not slowtest\"')",
 ]
-filterwarnings = [
+ini_options.filterwarnings = [
   "error",
   "ignore:this date/calendar/year zero convention is not supported by CF", # CFtime warning, probably harmless here?
   "ignore:Received exception when making HEAD request to",                 # In compliance_checker/protocols/netcdf.py::is_remote_netcdf We can still tell if it is remote without the handshake.


### PR DESCRIPTION
This PR changes the tests to run all supported Python version on ubuntu-slim (if that works here) and test macos and Windows only on latest Python. It also make the hyrax test as expected failure to due flaky server connection to that file.