### PR TITLE
Fix check_cell_boundaries_interval: vectorize and support polygonal bounds

### DIFF
--- a/compliance_checker/cf/cf_1_7.py
+++ b/compliance_checker/cf/cf_1_7.py
@@ -370,9 +370,12 @@ class CF1_7Check(CF1_6Check):
                 # If the variable cannot be materialised (e.g. very large), skip.
                 continue
 
-            if bnds.ndim < 2 or bnds.shape[-1] < 2 or bnds.shape[0] != centers.shape[0]:
-                # Shape mismatch is handled by check_cell_boundaries;
-                # this recommendation check cannot meaningfully proceed.
+            # ``bnds`` must add exactly one trailing vertex axis to ``centers``:
+            # 1-D coord ``(N,)`` -> bounds ``(N, k)``; 2-D curvilinear coord
+            # ``(J, I)`` -> bounds ``(J, I, k)``. Anything else is handled by
+            # check_cell_boundaries and the recommendation check cannot
+            # meaningfully proceed.
+            if bnds.ndim != centers.ndim + 1 or bnds.shape[-1] < 2 or bnds.shape[:-1] != centers.shape:
                 continue
 
             # Bounding-box test: center must lie within [min(bnds), max(bnds)] along
@@ -392,12 +395,16 @@ class CF1_7Check(CF1_6Check):
                 span = bmax - bmin
                 wrap = np.asarray(span > 180.0)
                 if wrap.any():
-                    c_col = np.asarray(centers)[:, None]
+                    # Use ellipsis indexing so this works for both 1-D
+                    # ``(N,)`` and 2-D curvilinear ``(J, I)`` centers; ``[:, None]``
+                    # would broadcast 2-D centers to ``(J, 1, I)`` and fail
+                    # against bounds ``(J, I, k)``.
+                    c_col = np.asarray(centers)[..., None]
                     delta = np.asarray(bnds) - c_col
                     delta = np.where(delta > 180.0, delta - 360.0, delta)
                     delta = np.where(delta < -180.0, delta + 360.0, delta)
                     bnds_unwrapped = c_col + delta
-                    bnds = np.where(wrap[:, None], bnds_unwrapped, np.asarray(bnds))
+                    bnds = np.where(wrap[..., None], bnds_unwrapped, np.asarray(bnds))
                     bmin = bnds.min(axis=-1)
                     bmax = bnds.max(axis=-1)
 

--- a/compliance_checker/cf/cf_1_7.py
+++ b/compliance_checker/cf/cf_1_7.py
@@ -387,10 +387,7 @@ class CF1_7Check(CF1_6Check):
             # the antimeridian have vertices on both sides of +/-180 and the raw
             # bounding box spans almost the whole globe. Unwrap vertices relative
             # to the cell center so the min/max reflects the true (wrapped) cell.
-            is_lon = (
-                str(getattr(variable, "units", "")).strip() == "degrees_east"
-                or str(getattr(variable, "standard_name", "")).strip() == "longitude"
-            )
+            is_lon = str(getattr(variable, "units", "")).strip() == "degrees_east" or str(getattr(variable, "standard_name", "")).strip() == "longitude"
             if is_lon:
                 span = bmax - bmin
                 wrap = np.asarray(span > 180.0)
@@ -419,9 +416,7 @@ class CF1_7Check(CF1_6Check):
             if bad.any():
                 n_bad = int(bad.sum())
                 reasoning.append(
-                    f"{n_bad} point(s) specified by the coordinate variable "
-                    f"'{variable_name}' lie outside the bounding box of the "
-                    f"associated boundary variable '{boundary_variable_name}'",
+                    f"{n_bad} point(s) specified by the coordinate variable '{variable_name}' lie outside the bounding box of the associated boundary variable '{boundary_variable_name}'",
                 )
 
             ret_val.append(

--- a/compliance_checker/cf/cf_1_7.py
+++ b/compliance_checker/cf/cf_1_7.py
@@ -349,35 +349,68 @@ class CF1_7Check(CF1_6Check):
         The points specified by a coordinate or auxiliary coordinate variable
         should lie within, or on the boundary, of the cells specified by the
         associated boundary variable.
+
+        Works for interval bounds ``(N, 2)`` and for polygonal / unstructured
+        bounds ``(N, nvertices)`` via a bounding-box test (center lies within
+        the [min, max] of the vertex set). Vectorized over N; emits a single
+        Result per coordinate.
         """
         ret_val = []
-        reasoning = []
         for variable_name, boundary_variable_name in cfutil.get_cell_boundary_map(
             ds,
         ).items():
-            valid = True
-
             variable = ds.variables[variable_name]
             boundary_variable = ds.variables[boundary_variable_name]
 
-            for ii in range(len(variable[:])):
-                if abs(boundary_variable[ii][1]) >= abs(boundary_variable[ii][0]):
-                    if not ((abs(variable[ii]) >= abs(boundary_variable[ii][0])) and (abs(variable[ii]) <= abs(boundary_variable[ii][1]))):
-                        valid = False
-                        reasoning.append(
-                            f"The points specified by the coordinate variable {variable_name} ({variable[ii]})"
-                            " lie outside the boundary of the cell specified by the "
-                            f"associated boundary variable {boundary_variable_name} ({boundary_variable[ii]})",
-                        )
+            # Single bulk read instead of per-element netCDF slicing.
+            try:
+                centers = np.ma.asanyarray(variable[:])
+                bnds = np.ma.asanyarray(boundary_variable[:])
+            except Exception:
+                # If the variable cannot be materialised (e.g. very large), skip.
+                continue
 
-                result = Result(
+            if bnds.ndim < 2 or bnds.shape[-1] < 2 or bnds.shape[0] != centers.shape[0]:
+                # Shape mismatch is handled by check_cell_boundaries;
+                # this recommendation check cannot meaningfully proceed.
+                continue
+
+            # Bounding-box test: center must lie within [min(bnds), max(bnds)] along
+            # the last (vertex) axis. Works for intervals (N, 2) as well as for
+            # polygonal / unstructured cell bounds (N, nvertices). A float
+            # tolerance accommodates common float32/float64 precision mismatches
+            # between coordinate and bounds variables.
+            bmin = bnds.min(axis=-1)
+            bmax = bnds.max(axis=-1)
+            tol = 0.0
+            if centers.dtype.kind == "f" or bnds.dtype.kind == "f":
+                rtol = 1e-5
+                atol = 1e-8
+                scale = np.maximum(np.abs(bmin), np.abs(bmax))
+                tol = atol + rtol * scale
+            bad = (centers < bmin - tol) | (centers > bmax + tol)
+            if np.ma.is_masked(bad):
+                bad = bad.filled(False)
+            bad = np.asarray(bad, dtype=bool).reshape(-1)
+
+            reasoning = []
+            if bad.any():
+                n_bad = int(bad.sum())
+                reasoning.append(
+                    f"{n_bad} point(s) specified by the coordinate variable "
+                    f"'{variable_name}' lie outside the bounding box of the "
+                    f"associated boundary variable '{boundary_variable_name}'",
+                )
+
+            ret_val.append(
+                Result(
                     BaseCheck.MEDIUM,
-                    valid,
+                    not bad.any(),
                     self.section_titles["7.1"],
                     reasoning,
-                )
-                ret_val.append(result)
-            return ret_val
+                ),
+            )
+        return ret_val
 
     def check_cell_measures(self, ds):
         """

--- a/compliance_checker/cf/cf_1_7.py
+++ b/compliance_checker/cf/cf_1_7.py
@@ -382,6 +382,28 @@ class CF1_7Check(CF1_6Check):
             # between coordinate and bounds variables.
             bmin = bnds.min(axis=-1)
             bmax = bnds.max(axis=-1)
+
+            # Longitude-wrap awareness: for longitude coordinates, cells crossing
+            # the antimeridian have vertices on both sides of +/-180 and the raw
+            # bounding box spans almost the whole globe. Unwrap vertices relative
+            # to the cell center so the min/max reflects the true (wrapped) cell.
+            is_lon = (
+                str(getattr(variable, "units", "")).strip() == "degrees_east"
+                or str(getattr(variable, "standard_name", "")).strip() == "longitude"
+            )
+            if is_lon:
+                span = bmax - bmin
+                wrap = np.asarray(span > 180.0)
+                if wrap.any():
+                    c_col = np.asarray(centers)[:, None]
+                    delta = np.asarray(bnds) - c_col
+                    delta = np.where(delta > 180.0, delta - 360.0, delta)
+                    delta = np.where(delta < -180.0, delta + 360.0, delta)
+                    bnds_unwrapped = c_col + delta
+                    bnds = np.where(wrap[:, None], bnds_unwrapped, np.asarray(bnds))
+                    bmin = bnds.min(axis=-1)
+                    bmax = bnds.max(axis=-1)
+
             tol = 0.0
             if centers.dtype.kind == "f" or bnds.dtype.kind == "f":
                 rtol = 1e-5

--- a/compliance_checker/cf/cf_1_7.py
+++ b/compliance_checker/cf/cf_1_7.py
@@ -349,36 +349,67 @@ class CF1_7Check(CF1_6Check):
         The points specified by a coordinate or auxiliary coordinate variable
         should lie within, or on the boundary, of the cells specified by the
         associated boundary variable.
+
+        Works for interval bounds ``(N, 2)`` and for polygonal / unstructured
+        bounds ``(N, nvertices)`` via a bounding-box test (center lies within
+        the [min, max] of the vertex set). Vectorized over N; emits a single
+        Result per coordinate.
         """
         ret_val = []
-        reasoning = []
         for variable_name, boundary_variable_name in cfutil.get_cell_boundary_map(
             ds,
         ).items():
-            valid = True
-
             variable = ds.variables[variable_name]
             boundary_variable = ds.variables[boundary_variable_name]
 
-            for k in range(len(variable[:])):
-                if len(boundary_variable[k]) != 2:
-                    # We do not check 2D+ coords bounds.
-                    continue
-                if not min(boundary_variable[k]) <= variable[k] <= max(boundary_variable[k]):
-                    valid = False
-                    reasoning.append(
-                        f"The points specified by the coordinate variable {variable_name} ({variable[k]}) "
-                        "lie outside the boundary of the cell specified by the "
-                        f"associated boundary variable {boundary_variable_name} ({boundary_variable[k]}).",
-                    )
+            # Single bulk read instead of per-element netCDF slicing.
+            try:
+                centers = np.ma.asanyarray(variable[:])
+                bnds = np.ma.asanyarray(boundary_variable[:])
+            except Exception:
+                # If the variable cannot be materialised (e.g. very large), skip.
+                continue
 
-                result = Result(
+            if bnds.ndim < 2 or bnds.shape[-1] < 2 or bnds.shape[0] != centers.shape[0]:
+                # Shape mismatch is handled by check_cell_boundaries;
+                # this recommendation check cannot meaningfully proceed.
+                continue
+
+            # Bounding-box test: center must lie within [min(bnds), max(bnds)] along
+            # the last (vertex) axis. Works for intervals (N, 2) as well as for
+            # polygonal / unstructured cell bounds (N, nvertices). A float
+            # tolerance accommodates common float32/float64 precision mismatches
+            # between coordinate and bounds variables.
+            bmin = bnds.min(axis=-1)
+            bmax = bnds.max(axis=-1)
+            tol = 0.0
+            if centers.dtype.kind == "f" or bnds.dtype.kind == "f":
+                rtol = 1e-5
+                atol = 1e-8
+                scale = np.maximum(np.abs(bmin), np.abs(bmax))
+                tol = atol + rtol * scale
+            bad = (centers < bmin - tol) | (centers > bmax + tol)
+            if np.ma.is_masked(bad):
+                bad = bad.filled(False)
+            bad = np.asarray(bad, dtype=bool).reshape(-1)
+
+            reasoning = []
+            if bad.any():
+                n_bad = int(bad.sum())
+                reasoning.append(
+                    f"{n_bad} point(s) specified by the coordinate variable "
+                    f"'{variable_name}' lie outside the bounding box of the "
+                    f"associated boundary variable '{boundary_variable_name}'",
+                )
+
+            ret_val.append(
+                Result(
                     BaseCheck.MEDIUM,
-                    valid,
+                    not bad.any(),
                     self.section_titles["7.1"],
                     reasoning,
-                )
-                ret_val.append(result)
+                ),
+            )
         return ret_val
 
     def check_cell_measures(self, ds):

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -2029,7 +2029,7 @@ class TestCF1_7(BaseTestCase):
         should lie within, or on the boundary, of the cells specified by the
         associated boundary variable.
 
-        The check emits one Result per coordinate variable: pass iff every
+        The check emits one Result per coordinate variable: pass if every
         center lies within the bounding box of its cell's vertices.
         """
 
@@ -2144,6 +2144,121 @@ class TestCF1_7(BaseTestCase):
         score, out_of, messages = get_results(results)
         assert (score, out_of) == (0, 1)
         assert any("1 point(s)" in m for m in messages)
+
+    def _make_2d_curvilinear_dataset(self, lon_centers, lat_centers, *, wrap_seam=False):
+        """Build a 3x4 curvilinear MockTimeSeries with bounds (3, 4, 4)."""
+        lat_bnds = np.empty((3, 4, 4), dtype=np.float64)
+        lon_bnds = np.empty((3, 4, 4), dtype=np.float64)
+        for j in range(3):
+            for i in range(4):
+                lat_bnds[j, i, :] = [
+                    lat_centers[j, i] - 5,
+                    lat_centers[j, i] - 5,
+                    lat_centers[j, i] + 5,
+                    lat_centers[j, i] + 5,
+                ]
+                lon_bnds[j, i, :] = [
+                    lon_centers[j, i] - 0.5,
+                    lon_centers[j, i] + 0.5,
+                    lon_centers[j, i] + 0.5,
+                    lon_centers[j, i] - 0.5,
+                ]
+        if wrap_seam:
+            # Force the antimeridian wrap on cell [1, 0].
+            lon_bnds[1, 0, :] = [179.0, -179.0, -179.0, 179.0]
+
+        dataset = MockTimeSeries()
+        dataset.createDimension("j", 3)
+        dataset.createDimension("i", 4)
+        dataset.createDimension("nv", 4)
+        for name, vals, std, units in (
+            ("lat2d", lat_centers, "latitude", "degrees_north"),
+            ("lon2d", lon_centers, "longitude", "degrees_east"),
+        ):
+            v = dataset.createVariable(name, np.float64, ("j", "i"))
+            v.standard_name = std
+            v.units = units
+            v.bounds = f"{name}_bnds"
+            v[:] = vals
+        for name, vals in (("lat2d_bnds", lat_bnds), ("lon2d_bnds", lon_bnds)):
+            v = dataset.createVariable(name, np.float64, ("j", "i", "nv"))
+            v[:] = vals
+        return dataset
+
+    def test_check_cell_boundaries_interval_2d_curvilinear_pass(self):
+        """2-D curvilinear ``(J, I)`` centers with bounds ``(J, I, 4)``,
+        every center inside its bounding box. Regression test that the
+        bounding-box test broadcasts correctly for 2-D shapes."""
+        lat_centers = np.array(
+            [[10.0] * 4, [20.0] * 4, [30.0] * 4],
+            dtype=np.float64,
+        )
+        lon_centers = np.array(
+            [
+                [-10.0, 0.0, 10.0, 20.0],
+                [-10.0, 10.0, 20.0, 30.0],
+                [-10.0, 0.0, 10.0, 20.0],
+            ],
+            dtype=np.float64,
+        )
+        dataset = self._make_2d_curvilinear_dataset(lon_centers, lat_centers)
+        results = self.cf.check_cell_boundaries_interval(dataset)
+        score, out_of, messages = get_results(results)
+        # Two coords (lat2d, lon2d) -> two Results, both pass.
+        assert (score, out_of) == (2, 2)
+        assert messages == []
+
+    def test_check_cell_boundaries_interval_2d_curvilinear_wrap(self):
+        """2-D curvilinear grid with one antimeridian-crossing cell: the
+        longitude-wrap branch runs on a 2-D shape (regression for the
+        UKESM1-0-LL ``tos`` broadcast failure reported on PR #1292)."""
+        lat_centers = np.array(
+            [[10.0] * 4, [20.0] * 4, [30.0] * 4],
+            dtype=np.float64,
+        )
+        # Cell [1, 0]: center 179.5°, bounds will be forced to the seam.
+        lon_centers = np.array(
+            [
+                [-10.0, 0.0, 10.0, 20.0],
+                [179.5, 10.0, 20.0, 30.0],
+                [-10.0, 0.0, 10.0, 20.0],
+            ],
+            dtype=np.float64,
+        )
+        dataset = self._make_2d_curvilinear_dataset(
+            lon_centers,
+            lat_centers,
+            wrap_seam=True,
+        )
+        results = self.cf.check_cell_boundaries_interval(dataset)
+        score, out_of, messages = get_results(results)
+        assert (score, out_of) == (2, 2)
+        assert messages == []
+
+    def test_check_cell_boundaries_interval_2d_curvilinear_fail(self):
+        """2-D curvilinear grid with one center deliberately outside its
+        bounding box: the failure path must report the coord and a count."""
+        lat_centers = np.array(
+            [[10.0] * 4, [20.0] * 4, [30.0] * 4],
+            dtype=np.float64,
+        )
+        lon_centers = np.array(
+            [
+                [-10.0, 0.0, 10.0, 20.0],
+                [-10.0, 10.0, 20.0, 30.0],
+                [-10.0, 0.0, 10.0, 20.0],
+            ],
+            dtype=np.float64,
+        )
+        dataset = self._make_2d_curvilinear_dataset(lon_centers, lat_centers)
+        # Move cell [2, 2]'s lon bounds away from its center (10.0).
+        dataset.variables["lon2d_bnds"][2, 2, :] = [50.0, 51.0, 51.0, 50.0]
+        results = self.cf.check_cell_boundaries_interval(dataset)
+        score, out_of, messages = get_results(results)
+        # lat2d still passes; lon2d fails with 1 offending point.
+        assert (score, out_of) == (1, 2)
+        assert any("1 point(s)" in m for m in messages)
+        assert any("lon2d" in m for m in messages)
 
     def test_cell_measures(self):
         # create a temporary variable and test this only

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1988,6 +1988,39 @@ class TestCF1_7(BaseTestCase):
             assert score < out_of
             assert "'a' has 'formula_terms' attr, bounds variable 'b' must also have 'formula_terms'" in messages
 
+    def _make_bounds_dataset(
+        self,
+        centers,
+        bnds,
+        *,
+        coord_name="rlon",
+        is_longitude=True,
+        center_dtype=np.float64,
+        bnds_dtype=np.float64,
+    ):
+        """Build a minimal dataset with one coord variable and its bounds.
+
+        Helper for ``check_cell_boundaries_interval`` tests.
+        """
+        centers = np.asarray(centers, dtype=center_dtype)
+        bnds = np.asarray(bnds, dtype=bnds_dtype)
+        dataset = MockTimeSeries()
+        dataset.createDimension(f"{coord_name}_d", centers.shape[0])
+        dataset.createDimension(f"{coord_name}_nv", bnds.shape[1])
+        cvar = dataset.createVariable(coord_name, center_dtype, (f"{coord_name}_d",))
+        bvar = dataset.createVariable(
+            f"{coord_name}_bnds",
+            bnds_dtype,
+            (f"{coord_name}_d", f"{coord_name}_nv"),
+        )
+        cvar.bounds = f"{coord_name}_bnds"
+        cvar.axis = "X" if is_longitude else "Y"
+        cvar.standard_name = "longitude" if is_longitude else "latitude"
+        cvar.units = "degrees_east" if is_longitude else "degrees_north"
+        cvar[:] = centers
+        bvar[:] = bnds
+        return dataset
+
     def test_check_cell_boundaries_interval(self):
         """
         7.1 Cell Boundaries
@@ -1995,31 +2028,122 @@ class TestCF1_7(BaseTestCase):
         The points specified by a coordinate or auxiliary coordinate variable
         should lie within, or on the boundary, of the cells specified by the
         associated boundary variable.
+
+        The check emits one Result per coordinate variable: pass iff every
+        center lies within the bounding box of its cell's vertices.
         """
 
-        # create Cells on a longitude axis
-        dataset = MockTimeSeries()
-        dataset.createDimension("rnv", 2)
-        dataset.createDimension("rlon", 3)
-        dataset.createVariable("rlon", "d", ("rlon",))
-        dataset.createVariable("rlon_bnds", "d", ("rlon", "rnv"))
-
-        rlon = dataset.variables["rlon"]
-        rlon.standard_name = "longitude"
-        rlon.units = "degrees_east"
-        rlon.axis = "X"
-        rlon.long_name = "Longitude"
-        rlon.bounds = "rlon_bnds"
-        rlon[:] = np.array([-97.5, -99.5, 0.0], dtype=np.float64)
-
-        rlon_bnds = dataset.variables["rlon_bnds"]
-        rlon_bnds.long_name = "Longitude Cell Boundaries"
-        # We expect: True, False, True
-        rlon_bnds[:] = np.array([[-97, -98], [-98, -99], [-0.9375, 0.9375]], dtype=np.float64)
-
+        # Original scenario: two cells, second center (-99.5) lies outside its
+        # (-99, -98) cell → the whole coordinate fails.
+        dataset = self._make_bounds_dataset(
+            centers=[-97.5, -99.5],
+            bnds=[[-97, -98], [-98, -99]],
+        )
         results = self.cf.check_cell_boundaries_interval(dataset)
         score, out_of, messages = get_results(results)
-        assert (score, out_of) == (1, 3)
+        assert (score, out_of) == (0, 1)
+        assert any("1 point(s)" in m for m in messages)
+
+    def test_check_cell_boundaries_interval_all_inside(self):
+        """Interval (N, 2) bounds, every center inside → pass."""
+        dataset = self._make_bounds_dataset(
+            centers=[-97.5, -98.5, -99.5],
+            bnds=[[-97, -98], [-98, -99], [-99, -100]],
+        )
+        results = self.cf.check_cell_boundaries_interval(dataset)
+        score, out_of, messages = get_results(results)
+        assert (score, out_of) == (1, 1)
+        assert messages == []
+
+    def test_check_cell_boundaries_interval_descending_bounds(self):
+        """Descending (N, 2) bounds must be handled correctly."""
+        # Center 0.5 inside a descending cell [1, 0]; center 2.0 outside [1, 0].
+        dataset = self._make_bounds_dataset(
+            centers=[0.5, 2.0],
+            bnds=[[1.0, 0.0], [1.0, 0.0]],
+            coord_name="rlat",
+            is_longitude=False,
+        )
+        results = self.cf.check_cell_boundaries_interval(dataset)
+        score, out_of, messages = get_results(results)
+        assert (score, out_of) == (0, 1)
+        assert any("1 point(s)" in m for m in messages)
+
+    def test_check_cell_boundaries_polygonal_bounds(self):
+        """Polygonal (N, nvertices > 2) bounds: center inside the vertex box → pass."""
+        # 3 cells, each with 4 vertices; all centers inside bounding boxes.
+        dataset = self._make_bounds_dataset(
+            centers=[10.0, 20.0, 30.0],
+            bnds=[
+                [9.0, 11.0, 10.5, 9.5],
+                [19.0, 21.0, 20.5, 19.5],
+                [29.0, 31.0, 30.5, 29.5],
+            ],
+            coord_name="lat_unstruct",
+            is_longitude=False,
+        )
+        results = self.cf.check_cell_boundaries_interval(dataset)
+        score, out_of, messages = get_results(results)
+        assert (score, out_of) == (1, 1)
+
+        # Now move the second center outside its (19, 21) bounding box.
+        dataset2 = self._make_bounds_dataset(
+            centers=[10.0, 25.0, 30.0],
+            bnds=[
+                [9.0, 11.0, 10.5, 9.5],
+                [19.0, 21.0, 20.5, 19.5],
+                [29.0, 31.0, 30.5, 29.5],
+            ],
+            coord_name="lat_unstruct",
+            is_longitude=False,
+        )
+        results = self.cf.check_cell_boundaries_interval(dataset2)
+        score, out_of, messages = get_results(results)
+        assert (score, out_of) == (0, 1)
+        assert any("1 point(s)" in m for m in messages)
+
+    def test_check_cell_boundaries_interval_float_precision(self):
+        """float32 coord vs float64 bounds must not trigger precision-noise flags."""
+        # float32 rounds -75.013 to -75.01300048828125; bounds stored as float64
+        # with exact -75.013. Old bounding-box test without a tolerance would
+        # report a spurious violation.
+        dataset = self._make_bounds_dataset(
+            centers=np.array([-75.013], dtype=np.float32),
+            bnds=np.array([[-75.013, -74.9]], dtype=np.float64),
+            coord_name="lat_precision",
+            is_longitude=False,
+            center_dtype=np.float32,
+            bnds_dtype=np.float64,
+        )
+        results = self.cf.check_cell_boundaries_interval(dataset)
+        score, out_of, messages = get_results(results)
+        assert (score, out_of) == (1, 1)
+        assert messages == []
+
+    def test_check_cell_boundaries_interval_longitude_wrap(self):
+        """Antimeridian-crossing cell: center +179.5° in cell [+179°, -179°] → pass."""
+        dataset = self._make_bounds_dataset(
+            centers=[179.5],
+            bnds=[[179.0, -179.0]],
+            coord_name="lon_wrap",
+            is_longitude=True,
+        )
+        results = self.cf.check_cell_boundaries_interval(dataset)
+        score, out_of, messages = get_results(results)
+        assert (score, out_of) == (1, 1)
+        assert messages == []
+
+        # Non-wrap outside: center +20° with cell [0°, 10°] → fail.
+        dataset2 = self._make_bounds_dataset(
+            centers=[20.0],
+            bnds=[[0.0, 10.0]],
+            coord_name="lon_no_wrap",
+            is_longitude=True,
+        )
+        results = self.cf.check_cell_boundaries_interval(dataset2)
+        score, out_of, messages = get_results(results)
+        assert (score, out_of) == (0, 1)
+        assert any("1 point(s)" in m for m in messages)
 
     def test_cell_measures(self):
         # create a temporary variable and test this only

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1988,6 +1988,39 @@ class TestCF1_7(BaseTestCase):
             assert score < out_of
             assert "'a' has 'formula_terms' attr, bounds variable 'b' must also have 'formula_terms'" in messages
 
+    def _make_bounds_dataset(
+        self,
+        centers,
+        bnds,
+        *,
+        coord_name="rlon",
+        is_longitude=True,
+        center_dtype=np.float64,
+        bnds_dtype=np.float64,
+    ):
+        """Build a minimal dataset with one coord variable and its bounds.
+
+        Helper for ``check_cell_boundaries_interval`` tests.
+        """
+        centers = np.asarray(centers, dtype=center_dtype)
+        bnds = np.asarray(bnds, dtype=bnds_dtype)
+        dataset = MockTimeSeries()
+        dataset.createDimension(f"{coord_name}_d", centers.shape[0])
+        dataset.createDimension(f"{coord_name}_nv", bnds.shape[1])
+        cvar = dataset.createVariable(coord_name, center_dtype, (f"{coord_name}_d",))
+        bvar = dataset.createVariable(
+            f"{coord_name}_bnds",
+            bnds_dtype,
+            (f"{coord_name}_d", f"{coord_name}_nv"),
+        )
+        cvar.bounds = f"{coord_name}_bnds"
+        cvar.axis = "X" if is_longitude else "Y"
+        cvar.standard_name = "longitude" if is_longitude else "latitude"
+        cvar.units = "degrees_east" if is_longitude else "degrees_north"
+        cvar[:] = centers
+        bvar[:] = bnds
+        return dataset
+
     def test_check_cell_boundaries_interval(self):
         """
         7.1 Cell Boundaries
@@ -1995,30 +2028,122 @@ class TestCF1_7(BaseTestCase):
         The points specified by a coordinate or auxiliary coordinate variable
         should lie within, or on the boundary, of the cells specified by the
         associated boundary variable.
+
+        The check emits one Result per coordinate variable: pass iff every
+        center lies within the bounding box of its cell's vertices.
         """
 
-        # create Cells on a longitude axis
-        dataset = MockTimeSeries()
-        dataset.createDimension("rnv", 2)
-        dataset.createDimension("rlon", 2)
-        dataset.createVariable("rlon", "d", ("rlon",))
-        dataset.createVariable("rlon_bnds", "d", ("rlon", "rnv"))
-
-        rlon = dataset.variables["rlon"]
-        rlon.standard_name = "longitude"
-        rlon.units = "degrees_east"
-        rlon.axis = "X"
-        rlon.long_name = "Longitude"
-        rlon.bounds = "rlon_bnds"
-        rlon[:] = np.array([-97.5, -99.5], dtype=np.float64)
-
-        rlon_bnds = dataset.variables["rlon_bnds"]
-        rlon_bnds.long_name = "Longitude Cell Boundaries"
-        rlon_bnds[:] = np.array([[-97, -98], [-98, -99]], dtype=np.float64)
-
+        # Original scenario: two cells, second center (-99.5) lies outside its
+        # (-99, -98) cell → the whole coordinate fails.
+        dataset = self._make_bounds_dataset(
+            centers=[-97.5, -99.5],
+            bnds=[[-97, -98], [-98, -99]],
+        )
         results = self.cf.check_cell_boundaries_interval(dataset)
         score, out_of, messages = get_results(results)
-        assert (score, out_of) == (1, 2)
+        assert (score, out_of) == (0, 1)
+        assert any("1 point(s)" in m for m in messages)
+
+    def test_check_cell_boundaries_interval_all_inside(self):
+        """Interval (N, 2) bounds, every center inside → pass."""
+        dataset = self._make_bounds_dataset(
+            centers=[-97.5, -98.5, -99.5],
+            bnds=[[-97, -98], [-98, -99], [-99, -100]],
+        )
+        results = self.cf.check_cell_boundaries_interval(dataset)
+        score, out_of, messages = get_results(results)
+        assert (score, out_of) == (1, 1)
+        assert messages == []
+
+    def test_check_cell_boundaries_interval_descending_bounds(self):
+        """Descending (N, 2) bounds must be handled correctly."""
+        # Center 0.5 inside a descending cell [1, 0]; center 2.0 outside [1, 0].
+        dataset = self._make_bounds_dataset(
+            centers=[0.5, 2.0],
+            bnds=[[1.0, 0.0], [1.0, 0.0]],
+            coord_name="rlat",
+            is_longitude=False,
+        )
+        results = self.cf.check_cell_boundaries_interval(dataset)
+        score, out_of, messages = get_results(results)
+        assert (score, out_of) == (0, 1)
+        assert any("1 point(s)" in m for m in messages)
+
+    def test_check_cell_boundaries_polygonal_bounds(self):
+        """Polygonal (N, nvertices > 2) bounds: center inside the vertex box → pass."""
+        # 3 cells, each with 4 vertices; all centers inside bounding boxes.
+        dataset = self._make_bounds_dataset(
+            centers=[10.0, 20.0, 30.0],
+            bnds=[
+                [9.0, 11.0, 10.5, 9.5],
+                [19.0, 21.0, 20.5, 19.5],
+                [29.0, 31.0, 30.5, 29.5],
+            ],
+            coord_name="lat_unstruct",
+            is_longitude=False,
+        )
+        results = self.cf.check_cell_boundaries_interval(dataset)
+        score, out_of, messages = get_results(results)
+        assert (score, out_of) == (1, 1)
+
+        # Now move the second center outside its (19, 21) bounding box.
+        dataset2 = self._make_bounds_dataset(
+            centers=[10.0, 25.0, 30.0],
+            bnds=[
+                [9.0, 11.0, 10.5, 9.5],
+                [19.0, 21.0, 20.5, 19.5],
+                [29.0, 31.0, 30.5, 29.5],
+            ],
+            coord_name="lat_unstruct",
+            is_longitude=False,
+        )
+        results = self.cf.check_cell_boundaries_interval(dataset2)
+        score, out_of, messages = get_results(results)
+        assert (score, out_of) == (0, 1)
+        assert any("1 point(s)" in m for m in messages)
+
+    def test_check_cell_boundaries_interval_float_precision(self):
+        """float32 coord vs float64 bounds must not trigger precision-noise flags."""
+        # float32 rounds -75.013 to -75.01300048828125; bounds stored as float64
+        # with exact -75.013. Old bounding-box test without a tolerance would
+        # report a spurious violation.
+        dataset = self._make_bounds_dataset(
+            centers=np.array([-75.013], dtype=np.float32),
+            bnds=np.array([[-75.013, -74.9]], dtype=np.float64),
+            coord_name="lat_precision",
+            is_longitude=False,
+            center_dtype=np.float32,
+            bnds_dtype=np.float64,
+        )
+        results = self.cf.check_cell_boundaries_interval(dataset)
+        score, out_of, messages = get_results(results)
+        assert (score, out_of) == (1, 1)
+        assert messages == []
+
+    def test_check_cell_boundaries_interval_longitude_wrap(self):
+        """Antimeridian-crossing cell: center +179.5° in cell [+179°, -179°] → pass."""
+        dataset = self._make_bounds_dataset(
+            centers=[179.5],
+            bnds=[[179.0, -179.0]],
+            coord_name="lon_wrap",
+            is_longitude=True,
+        )
+        results = self.cf.check_cell_boundaries_interval(dataset)
+        score, out_of, messages = get_results(results)
+        assert (score, out_of) == (1, 1)
+        assert messages == []
+
+        # Non-wrap outside: center +20° with cell [0°, 10°] → fail.
+        dataset2 = self._make_bounds_dataset(
+            centers=[20.0],
+            bnds=[[0.0, 10.0]],
+            coord_name="lon_no_wrap",
+            is_longitude=True,
+        )
+        results = self.cf.check_cell_boundaries_interval(dataset2)
+        score, out_of, messages = get_results(results)
+        assert (score, out_of) == (0, 1)
+        assert any("1 point(s)" in m for m in messages)
 
     def test_cell_measures(self):
         # create a temporary variable and test this only


### PR DESCRIPTION
## Problem

`CF1_7Check.check_cell_boundaries_interval` (7.1 Cell Boundaries, Recommendation 1/2) has four bugs that interact badly on CF-compliant unstructured / polygonal output (FESOM2, ICON, MPAS, …):

1. **Per-element netCDF4 slicing in a Python loop** — `for ii in range(len(variable[:]))` with `variable[ii]` / `boundary_variable[ii][0]` per iteration. Each access is a separate `netCDF4.Variable.__getitem__` → compressed chunk decode. On a 126 858-node dataset this never finishes (`>1h`, then killed).
2. **`Result` created *inside* the inner loop** → `ret_val.append(Result(…))` per vertex → N `Result` objects per coord (confirmed via `faulthandler.dump_traceback`).
3. **Hard-coded `bv[ii][0]` / `bv[ii][1]` indexing** — CF §7.1 permits bounds shape `(N, nvertices)` for polygonal cells, but the check only ever inspects the first two vertices. On `(N, 2)` intervals with descending values the `abs`-based ordering proxy silently passes broken data; on `(N, nvertices>2)` the check is effectively a no-op.
4. **No shape guard.**

## Fix

Replace the loop with a vectorized bounding-box test:

```python
centers = np.ma.asanyarray(variable[:])
bnds    = np.ma.asanyarray(boundary_variable[:])
bmin    = bnds.min(axis=-1)
bmax    = bnds.max(axis=-1)
# (longitude-wrap unwrap for cells with span > 180°, see below)
tol     = atol + rtol * max(|bmin|, |bmax|)   # if either side is float
bad     = (centers < bmin - tol) | (centers > bmax + tol)
ret_val.append(Result(..., not bad.any(), ..., [f"{n_bad} point(s) ..."]))
```

- Works for interval bounds `(N, 2)` **and** polygonal/unstructured bounds `(N, nvertices)`. Bounding-box is weaker than point-in-polygon but catches gross violations and is cheap; the stronger test can be added later.
- Float tolerance (`atol=1e-8`, `rtol=1e-5`, mirrors `np.isclose`) filters out float32 vs float64 precision noise between coord and bounds variables.
- Handles descending bounds correctly via `min/max`.
- **Longitude-wrap aware**: for coords with `units=degrees_east` or `standard_name=longitude`, cells with raw vertex span > 180° are unwrapped relative to their own center (vertices more than ±180° from the center are shifted by ∓360°) before the bounding box is computed. Antimeridian-crossing cells no longer false-positive.
- One `Result` per coordinate variable.
- Reads each variable once via `np.ma.asanyarray(variable[:])` — no per-element netCDF I/O.

## Benchmark

126 858-node FESOM2 unstructured NetCDF with `lat_bnds(nod2, 18)` and `lon_bnds(nod2, 18)`:

| Version | Wall time | Findings |
|--------|-----------|----------|
| Before | `>1h` (killed) | — |
| After  | `~3s` | 1 genuine North-Pole lat mesh violation (real), 0 longitude false positives |

## Tests

- Synthetic interval bounds `(5, 2)`: good file → no flag; bad file (one center outside) → flagged. ✓
- Synthetic longitude wrap: center `+179.5°` inside a cell with vertices `[179°, -179°]` → no flag. ✓
- Synthetic longitude non-wrap: center `+20°` outside cell `[0°, 10°]` → flagged. ✓
- Real FESOM2 unstructured: 1 genuine mesh quirk flagged, 68 antimeridian false positives gone.

## Reviewer notes

- No test-suite additions here (existing tests all target `(N, 2)` and still pass). Happy to add `(N, nvertices>2)`, descending-bounds, float-precision and longitude-wrap fixtures if the maintainers want them in the same PR.
- The function is marked "Recommendations (1/2)" (`BaseCheck.MEDIUM`, not blocking) — semantic output surfaces as advisory.