### PR TITLE
Security: Network requests lack explicit timeout, enabling request hang/DoS

### DIFF
--- a/compliance_checker/protocols/opendap.py
+++ b/compliance_checker/protocols/opendap.py
@@ -26,7 +26,7 @@ def create_DAP_variable_str(url):
     """
 
     # get dds
-    with urllib.request.urlopen(f"{url}.dds") as resp:
+    with urllib.request.urlopen(f"{url}.dds", timeout=10) as resp:
         _str = resp.read().decode()[8:]
 
     # remove beginning and ending braces, split on newlines
@@ -58,7 +58,7 @@ def is_opendap(url):
         das_url = url + ".das"
 
     try:
-        response = requests.get(das_url, allow_redirects=True)
+        response = requests.get(das_url, allow_redirects=True, timeout=(3, 10))
 
         if "xdods-server" in response.headers:
             return True
@@ -67,4 +67,6 @@ def is_opendap(url):
             return True
     except requests.exceptions.InvalidSchema:
         return False  # not opendap if url + ".das" isn't found
+    except requests.exceptions.Timeout:
+        return False
     return False


### PR DESCRIPTION
## Summary

Security: Network requests lack explicit timeout, enabling request hang/DoS

## Problem

**Severity**: `Medium` | **File**: `compliance_checker/protocols/opendap.py:L31`

Remote calls in `is_opendap` and `create_DAP_variable_str` do not define timeouts. A slow or non-responsive endpoint can cause the process/thread to block indefinitely, which can be leveraged for denial-of-service in long-running services.

## Solution

Set explicit connect/read timeouts on all remote requests (e.g., `requests.get(..., timeout=(3, 10))` and `urllib.request.urlopen(..., timeout=10)`) and handle timeout exceptions gracefully.

## Changes

- `compliance_checker/protocols/opendap.py` (modified)