### PR TITLE
Fix CF-1.9 check_domain_variables crashes on malformed domain variables and ragged arrays (#1318)

### DIFF
--- a/compliance_checker/cf/cf_1_9.py
+++ b/compliance_checker/cf/cf_1_9.py
@@ -187,7 +187,7 @@ class CF1_9Check(CF1_8Check):
                     "dimensions",
                 )
                 if dim_errors:
-                    errors_str = ", ".join(dim_errors)
+                    errors_str = ", ".join(err.name for err in dim_errors)
                     domain_valid.messages.append(
                         f"Could not find the following dimensions referenced in dimensions attribute from domain variable {domain_var.name}: {errors_str}",
                     )

--- a/compliance_checker/cf/util.py
+++ b/compliance_checker/cf/util.py
@@ -1177,9 +1177,9 @@ def resolve_ragged_array_dimension(ds: Dataset):
             instance_dimension=lambda s: isinstance(s, str),
         )
         ragged_type = "instance_dimension"
-    if ragged_variable is None:
+    if not ragged_variable:
         raise ValueError("Could not find a ragged array related variable")
-    return ragged_type
+    return ragged_variable[0], ragged_type
 
 
 def is_variable_valid_ragged_array_repr_featureType(nc, variable: str) -> bool:
@@ -2223,7 +2223,7 @@ class VariableReferenceError(Exception):
         self.dataset_path = dataset.filepath() if dataset is not None else None
 
     def __str__(self):
-        return f"Cannot find variable named {self.name} in dataset {self}.dataset_path"
+        return f"Cannot find variable named {self.name} in dataset {self.dataset_path}"
 
 
 class StandardNameTable:

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -3647,6 +3647,19 @@ class TestCF1_9(BaseTestCase):
         results = self.cf.check_domain_variables(dataset)
         assert results[0].value[0] == results[0].value[1]
 
+    def test_domain_invalid_dimensions(self):
+        # TEST CONFORMANCE 5.8 REQUIRED 2/4
+        # a domain variable with a dimensions attribute referencing a
+        # nonexistent dimension should fail the check, not crash it
+        dataset = MockTimeSeries()
+        domain_var = dataset.createVariable("domain", "c", ())
+        domain_var.long_name = "Domain variable"
+        domain_var.coordinates = "lon lat depth"
+        domain_var.setncattr("dimensions", "xyxz")
+        results = self.cf.check_domain_variables(dataset)
+        assert results[0].value[0] != results[0].value[1]
+        assert "Could not find the following dimensions referenced in dimensions attribute from domain variable domain: xyxz" in results[0].msgs
+
 
 class TestCF1_11(BaseTestCase):
     def setup_method(self):
@@ -4114,3 +4127,27 @@ class TestCFUtil(BaseTestCase):
                 "trajectoryprofile",
             )
         )
+
+    def test_resolve_ragged_array_dimension(self):
+        # must return both the variable bearing the ragged array
+        # attribute and the attribute name, as unpacked by
+        # CF1_9Check.check_domain_variables
+        nc = MockRaggedArrayRepr("timeseries", "contiguous")
+        ragged_variable, ragged_type = cfutil.resolve_ragged_array_dimension(nc)
+        assert ragged_variable.name == "counter_var"
+        assert ragged_type == "sample_dimension"
+
+        nc = MockRaggedArrayRepr("timeseries", "indexed")
+        ragged_variable, ragged_type = cfutil.resolve_ragged_array_dimension(nc)
+        assert ragged_variable.name == "index_var"
+        assert ragged_type == "instance_dimension"
+
+        # no ragged array related variables present
+        nc = MockTimeSeries()
+        with pytest.raises(ValueError):
+            cfutil.resolve_ragged_array_dimension(nc)
+
+    def test_variable_reference_error_str(self):
+        # str() must not recurse into __str__ via {self}
+        err = cfutil.VariableReferenceError("foo")
+        assert str(err) == "Cannot find variable named foo in dataset None"


### PR DESCRIPTION
# Fix CF-1.9 `check_domain_variables` crashes on malformed domain variables and ragged arrays

## Summary

The CF-1.9 (and inherited 1.10/1.11) `check_domain_variables` check crashes with an unhandled exception instead of reporting a failed `Result` in two situations, and the exception class it relies on cannot even be stringified. This PR fixes all three interlocking defects so the check degrades into failed results/messages the way it was designed to. Under `run_all` the crashes are swallowed, so today the check silently produces no result for exactly the malformed inputs it exists to flag.

Fixes #1318

## Root cause

`VariableReferenceError.__str__` interpolates `{self}` instead of `{self.dataset_path}`, recursing into itself (`RecursionError`); the domain `dimensions`-attribute branch joins the `VariableReferenceError` objects themselves (`", ".join(dim_errors)` → `TypeError`); and `resolve_ragged_array_dimension` returns only the attribute-name string while its sole caller unpacks `(variable, attribute_name)` (`ValueError: too many values to unpack`).

## What the fix changes

- `compliance_checker/cf/util.py` — `VariableReferenceError.__str__`: `{self}.dataset_path` → `{self.dataset_path}` (the `.dataset_path` was a literal outside the brace).
- `compliance_checker/cf/cf_1_9.py` — `", ".join(dim_errors)` → `", ".join(err.name for err in dim_errors)`, matching the sibling coordinates branch a few lines below.
- `compliance_checker/cf/util.py` — `resolve_ragged_array_dimension` now returns `(ragged_variable[0], ragged_type)`, exactly what `check_domain_variables` unpacks. The dead `if ragged_variable is None` guard (`get_variables_by_attributes` returns a list, never `None`) is replaced with an emptiness check so the intended `ValueError("Could not find a ragged array related variable")` can actually fire.

Three regression tests added in `compliance_checker/tests/test_cf.py`:

- `TestCF1_9::test_domain_invalid_dimensions` — a domain variable whose `dimensions` attribute names a missing dimension produces a failed `Result` with the expected message (previously `TypeError`).
- `TestCFUtil::test_resolve_ragged_array_dimension` — contiguous and indexed ragged datasets resolve to `(variable, attribute name)` (previously `ValueError` on unpack), and a dataset without ragged-array variables raises the intended `ValueError`.
- `TestCFUtil::test_variable_reference_error_str` — `str(VariableReferenceError(...))` returns the expected string (previously `RecursionError`).

Note: with this fix the ragged-array branch gets past `resolve_ragged_array_dimension`, but `check_domain_variables` line ~145 still iterates the `(references, errors)` tuple returned by `reference_attr_variables(ds, dim_name, " ", "dimensions")` rather than the references list — a separate latent defect left out of this PR to keep it minimal.

## Test evidence

Regression tests with the source fix temporarily reverted (`git stash` of `cf/util.py` + `cf/cf_1_9.py`, tests kept):

```
compliance_checker/tests/test_cf.py::TestCF1_9::test_domain_invalid_dimensions FAILED
    compliance_checker\cf\cf_1_9.py:190: TypeError: sequence item 0: expected str instance, VariableReferenceError found
compliance_checker/tests/test_cf.py::TestCFUtil::test_resolve_ragged_array_dimension FAILED
    ValueError: too many values to unpack (expected 2)
compliance_checker/tests/test_cf.py::TestCFUtil::test_variable_reference_error_str FAILED
    compliance_checker\cf\util.py:2226: RecursionError: maximum recursion depth exceeded
3 failed in 4.44s
```

With the fix applied:

```
compliance_checker/tests/test_cf.py::TestCF1_9::test_domain_invalid_dimensions PASSED
compliance_checker/tests/test_cf.py::TestCFUtil::test_resolve_ragged_array_dimension PASSED
compliance_checker/tests/test_cf.py::TestCFUtil::test_variable_reference_error_str PASSED
3 passed in 1.33s
```

Honest caveat on local suite coverage: the development box has no `ncgen` (netCDF C tools), so the `.cdl`-fixture-based tests (most of `test_cf.py`, `test_acdd.py`, etc.) cannot run locally — including the fixture portion of the existing `test_domain`. The new tests use only in-memory `MockNetCDF`/`MockTimeSeries`/`MockRaggedArrayRepr` datasets and need no fixtures. The fixture-free subset (`test_base`, `test_util`, `test_protocols`, `test_suite`) was run on this branch and on `main` as a baseline: identical results — `7 failed, 18 passed, 8 skipped, 1 xfailed`, where all 7 failures are the pre-existing `ncgen` `FileNotFoundError` environment issue on both runs. Full fixture suite should be exercised by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
