### PR TITLE
Fix is_netcdf matching any path ending in the letters "nc" (#1319)

### DIFF
--- a/compliance_checker/protocols/netcdf.py
+++ b/compliance_checker/protocols/netcdf.py
@@ -21,7 +21,7 @@ def is_netcdf(url):
         return False
 
     # If it's a known extension, give it a shot
-    if url.endswith("nc"):
+    if url.endswith(".nc"):
         return True
 
     try:

--- a/compliance_checker/tests/test_protocols.py
+++ b/compliance_checker/tests/test_protocols.py
@@ -8,7 +8,7 @@ import platform
 
 import pytest
 
-from compliance_checker.protocols import zarr
+from compliance_checker.protocols import netcdf, zarr
 from compliance_checker.suite import CheckSuite
 
 from .conftest import datadir
@@ -19,6 +19,24 @@ pytestmark = [pytest.mark.integration]
 @pytest.fixture
 def cs():
     return CheckSuite()
+
+
+extension_io = [
+    ("myfunc", False),
+    ("data.sync", False),
+    ("stats.inc", False),
+    ("foo.nc", True),
+]
+
+
+@pytest.mark.parametrize("url_in, expected", extension_io)
+def test_is_netcdf_extension(url_in, expected):
+    """
+    Test that only paths with a proper .nc extension are assumed to be netCDF
+    files; other paths ending in the letters "nc" must fall through to
+    inspecting the file contents.
+    """
+    assert netcdf.is_netcdf(url_in) == expected
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
# Fix `is_netcdf` matching any path ending in the letters "nc"

## Summary

`protocols/netcdf.py::is_netcdf` uses `url.endswith("nc")` as its extension shortcut, so any path whose name merely ends in the two letters "nc" — `myfunc`, `data.sync`, `stats.inc` — is classified as a netCDF file. Via `suite.load_local_dataset` such files are handed straight to `netCDF4.Dataset`, which fails with an opaque `OSError` instead of letting them fall through to the magic-number content checks and the `GenericFile` fallback. This PR requires the full `.nc` extension.

Fixes #1319

## Root cause

The extension check is missing the dot: `endswith("nc")` matches a 2-letter suffix, not a file extension.

## What the fix changes

- `compliance_checker/protocols/netcdf.py`: `url.endswith("nc")` → `url.endswith(".nc")`.

The function has no other extension cases to update: `.nc4` (and anything else) never matched the old 2-letter check either — those paths are unaffected and still fall through to the `is_classic_netcdf`/`is_hdf5` magic-number sniffing, which keeps working for real netCDF files regardless of name.

Regression test added in `compliance_checker/tests/test_protocols.py` (parametrized, in the style of `test_as_zarr`): `myfunc`, `data.sync`, `stats.inc` → `False`; `foo.nc` → `True`. No real files are needed — the non-`.nc` names fall through to `open()`, whose `OSError`/`FileNotFoundError` path correctly returns `False`.

## Test evidence

With the fix temporarily reverted (`git stash` of `protocols/netcdf.py`, test kept):

```
FAILED compliance_checker/tests/test_protocols.py::test_is_netcdf_extension[myfunc-False]
FAILED compliance_checker/tests/test_protocols.py::test_is_netcdf_extension[data.sync-False]
FAILED compliance_checker/tests/test_protocols.py::test_is_netcdf_extension[stats.inc-False]
3 failed, 1 passed, 12 deselected in 3.45s
```

With the fix applied:

```
compliance_checker/tests/test_protocols.py::test_is_netcdf_extension[myfunc-False] PASSED
compliance_checker/tests/test_protocols.py::test_is_netcdf_extension[data.sync-False] PASSED
compliance_checker/tests/test_protocols.py::test_is_netcdf_extension[stats.inc-False] PASSED
compliance_checker/tests/test_protocols.py::test_is_netcdf_extension[foo.nc-True] PASSED
4 passed, 12 deselected in 0.41s
```

Suite check: the development box has no `ncgen` (netCDF C tools), so the `.cdl`-fixture-based tests cannot run locally. The fixture-free subset (`test_base`, `test_util`, `test_protocols`, `test_suite`) was run on this branch vs. a `main` baseline: `7 failed, 22 passed, 8 skipped, 1 xfailed` vs. baseline `7 failed, 18 passed, 8 skipped, 1 xfailed` — the +4 passes are the new parametrized cases; all 7 failures are the same pre-existing `ncgen` `FileNotFoundError` environment issue on both runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
