### PR TITLE
cf §7.2: support multiple cell_measures entries per CF 1.11

### DIFF
--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -2796,79 +2796,95 @@ class CF1_6Check(CFNCCheck):
 
     def _cell_measures_core(self, ds, var, external_set, variable_template):
         # IMPLEMENTATION CONFORMANCE REQUIRED 1/2
+        # CF 1.11 §7.2: cell_measures may carry MULTIPLE measure entries
+        # ("area: a volume: v"), and each entry must be of a different type.
+        # Walk every "type: var" pair instead of trying to match the whole
+        # string as a single pair.
         reasoning = []
-        search_str = r"^(?P<measure_type>area|volume):\s+(?P<cell_measure_var_name>\w+)$"
-        search_res = regex.match(search_str, var.cell_measures)
-        if not search_res:
+        pair_re = r"(?P<measure_type>area|volume):\s+(?P<cell_measure_var_name>\w+)"
+        matches = list(regex.finditer(pair_re, var.cell_measures))
+        # Reject if the parsed pairs don't account for the whole attribute
+        # (catches malformed entries like ``area:`` with no variable or
+        # ``area: foo bogus volume: bar``). Compare on whitespace-normalised
+        # forms so the check accepts any consistent spacing variant.
+        canonical_from_pairs = " ".join(f"{m.group('measure_type')}: {m.group('cell_measure_var_name')}" for m in matches)
+        canonical_input = " ".join(var.cell_measures.split())
+        if not matches or canonical_from_pairs != canonical_input:
             valid = False
             reasoning.append(
                 f"The cell_measures attribute for variable {var.name} "
                 "is formatted incorrectly. It should take the "
-                "form of either 'area: cell_var' or "
-                "'volume: cell_var' where cell_var is an existing name of "
-                "a variable describing the cell measures.",
+                "form of 'area: cell_var', 'volume: cell_var', or "
+                "multiple such pairs separated by spaces (e.g. "
+                "'area: a volume: v'), where each cell_var is an "
+                "existing variable describing the cell measures.",
             )
-        else:
-            valid = True
-            cell_measure_var_name = search_res.group("cell_measure_var_name")
+            return Result(
+                BaseCheck.MEDIUM,
+                valid,
+                (self.section_titles["7.2"]),
+                reasoning,
+            )
+        seen_types = set()
+        valid = True
+        for search_res in matches:
             cell_measure_type = search_res.group("measure_type")
-            # TODO: cache previous results
+            cell_measure_var_name = search_res.group("cell_measure_var_name")
+            # CF 1.11 §7.2: "Multiple measures may be specified for the
+            # same variable, but they should be of different types."
+            if cell_measure_type in seen_types:
+                valid = False
+                reasoning.append(
+                    f"The cell_measures attribute for variable {var.name} has more than one '{cell_measure_type}' entry; each measure type may only appear once.",
+                )
+                continue
+            seen_types.add(cell_measure_type)
             if cell_measure_var_name not in set(ds.variables.keys()).union(
                 external_set,
             ):
                 valid = False
                 reasoning.append(
-                    f"Cell measure variable {cell_measure_var_name} referred to by {var.name} is not present in {variable_template}s".format(
-                        cell_measure_var_name,
-                        var.name,
-                    ),
+                    f"Cell measure variable {cell_measure_var_name} referred to by {var.name} is not present in {variable_template}s",
                 )
+                continue
             # CF 1.7+ assume external variables -- further checks can't be run here
-            elif cell_measure_var_name in external_set:
-                # can't test anything on an external var
-                return Result(
-                    BaseCheck.MEDIUM,
-                    valid,
-                    (self.section_titles["7.2"]),
-                    reasoning,
+            if cell_measure_var_name in external_set:
+                continue
+
+            cell_measure_var = ds.variables[cell_measure_var_name]
+            if not hasattr(cell_measure_var, "units"):
+                valid = False
+                reasoning.append(
+                    f"Cell measure variable {cell_measure_var_name} is required to have units attribute defined",
                 )
-
             else:
-                cell_measure_var = ds.variables[cell_measure_var_name]
-                if not hasattr(cell_measure_var, "units"):
+                # IMPLEMENTATION CONFORMANCE REQUIRED 2/2
+                exponent_lookup = {"area": 2, "volume": 3}
+                exponent = exponent_lookup[cell_measure_type]
+                conversion_failure_msg = (
+                    f'Variable "{cell_measure_var.name}" must have units which are convertible '
+                    f'to UDUNITS "m{exponent}" when variable is referred to by a {variable_template} with '
+                    f'cell_methods attribute with a measure type of "{cell_measure_type}".'
+                )
+                try:
+                    cell_measure_units = Unit(cell_measure_var.units)
+                except ValueError:
                     valid = False
-                    reasoning.append(
-                        f"Cell measure variable {cell_measure_var_name} is required to have units attribute defined",
-                    )
+                    reasoning.append(conversion_failure_msg)
                 else:
-                    # IMPLEMENTATION CONFORMANCE REQUIRED 2/2
-                    # verify this combination {area: 'm2', volume: 'm3'}
-
-                    # key is valid measure types, value is expected
-                    # exponent
-                    exponent_lookup = {"area": 2, "volume": 3}
-                    exponent = exponent_lookup[search_res.group("measure_type")]
-                    conversion_failure_msg = (
-                        f'Variable "{cell_measure_var.name}" must have units which are convertible '
-                        f'to UDUNITS "m{exponent}" when variable is referred to by a {variable_template} with '
-                        f'cell_methods attribute with a measure type of "{cell_measure_type}".'
-                    )
-                    try:
-                        cell_measure_units = Unit(cell_measure_var.units)
-                    except ValueError:
+                    if not cell_measure_units.is_convertible(
+                        Unit(f"m{exponent}"),
+                    ):
                         valid = False
                         reasoning.append(conversion_failure_msg)
-                    else:
-                        if not cell_measure_units.is_convertible(
-                            Unit(f"m{exponent}"),
-                        ):
-                            valid = False
-                            reasoning.append(conversion_failure_msg)
-                    if not set(cell_measure_var.dimensions).issubset(var.dimensions):
-                        valid = False
-                        reasoning.append(
-                            f"Cell measure variable {cell_measure_var_name} must have dimensions which are a subset of those defined in variable {var.name}.",
-                        )
+                # Dimension-subset check stays parallel to the unit checks
+                # (inside the ``has units`` branch) to preserve the original
+                # behaviour for cell_measure vars that lack a units attr.
+                if not set(cell_measure_var.dimensions).issubset(var.dimensions):
+                    valid = False
+                    reasoning.append(
+                        f"Cell measure variable {cell_measure_var_name} must have dimensions which are a subset of those defined in variable {var.name}.",
+                    )
 
         return Result(BaseCheck.MEDIUM, valid, (self.section_titles["7.2"]), reasoning)
 

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -2796,10 +2796,11 @@ class CF1_6Check(CFNCCheck):
 
     def _cell_measures_core(self, ds, var, external_set, variable_template):
         # IMPLEMENTATION CONFORMANCE REQUIRED 1/2
-        # CF 1.11 §7.2: cell_measures may carry MULTIPLE measure entries
-        # ("area: a volume: v"), and each entry must be of a different type.
-        # Walk every "type: var" pair instead of trying to match the whole
-        # string as a single pair.
+        # CF §7.2 has described cell_measures as "a list of blank-separated
+        # pairs of words of the form 'measure: name'" since CF 1.6, so a
+        # variable may carry more than one entry ("area: a volume: v").
+        # Walk every "measure: name" pair instead of matching the whole
+        # attribute as a single pair.
         reasoning = []
         pair_re = r"(?P<measure_type>area|volume):\s+(?P<cell_measure_var_name>\w+)"
         matches = list(regex.finditer(pair_re, var.cell_measures))
@@ -2830,8 +2831,10 @@ class CF1_6Check(CFNCCheck):
         for search_res in matches:
             cell_measure_type = search_res.group("measure_type")
             cell_measure_var_name = search_res.group("cell_measure_var_name")
-            # CF 1.11 §7.2: "Multiple measures may be specified for the
-            # same variable, but they should be of different types."
+            # CF §7.2 defines "area" and "volume" as the only measures and
+            # gives each one meaning, so two entries of the same type would
+            # have to disagree. The convention does not state this, so it is
+            # this checker's reading rather than a quotation.
             if cell_measure_type in seen_types:
                 valid = False
                 reasoning.append(

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -611,9 +611,9 @@ class TestCF1_6(BaseTestCase):
         score, out_of, messages = get_results(results)
         expected_message = (
             "The cell_measures attribute for variable PS is formatted incorrectly. "
-            "It should take the form of either 'area: cell_var' or 'volume: cell_var' "
-            "where cell_var is an existing name of a variable describing the "
-            "cell measures."
+            "It should take the form of 'area: cell_var', 'volume: cell_var', or "
+            "multiple such pairs separated by spaces (e.g. 'area: a volume: v'), "
+            "where each cell_var is an existing variable describing the cell measures."
         )
         assert expected_message in messages
 
@@ -653,6 +653,31 @@ class TestCF1_6(BaseTestCase):
         results = self.cf.check_cell_measures(dataset)
         score, out_of, messages = get_results(results)
         assert "Cell measure variable cell_area2 must have dimensions which are a subset of those defined in variable PS." in messages
+
+        # CF 1.11 §7.2: a variable may carry multiple cell_measures entries,
+        # one per measure type. Both entries should validate.
+        dataset_multi = MockTimeSeries()
+        dataset_multi.createVariable("PS", "d", ("time",))
+        dataset_multi.variables["PS"].setncattr(
+            "cell_measures",
+            "area: area_var volume: volume_var",
+        )
+        for name, units in (("area_var", "m2"), ("volume_var", "m3")):
+            v = dataset_multi.createVariable(name, "d", ("time",))
+            v.setncattr("units", units)
+        results = self.cf.check_cell_measures(dataset_multi)
+        score, out_of, messages = get_results(results)
+        assert score == out_of and score > 0, f"multi-measure case should pass but got messages: {messages}"
+
+        # CF 1.11 §7.2: each measure type may appear at most once. Reject a
+        # second 'area:' entry as malformed.
+        dataset_multi.variables["PS"].setncattr(
+            "cell_measures",
+            "area: area_var area: area_var",
+        )
+        results = self.cf.check_cell_measures(dataset_multi)
+        score, out_of, messages = get_results(results)
+        assert any("more than one 'area' entry" in m for m in messages), f"duplicate measure type should fail but messages were: {messages}"
 
     def test_climatology_cell_methods(self):
         """
@@ -2278,9 +2303,10 @@ class TestCF1_7(BaseTestCase):
             score, out_of, messages = get_results(results)
             assert (
                 "The cell_measures attribute for variable PS is formatted "
-                "incorrectly. It should take the form of either 'area: "
-                "cell_var' or 'volume: cell_var' where cell_var is an "
-                "existing name of a variable describing the cell measures." in messages
+                "incorrectly. It should take the form of 'area: cell_var', "
+                "'volume: cell_var', or multiple such pairs separated by spaces "
+                "(e.g. 'area: a volume: v'), where each cell_var is an existing "
+                "variable describing the cell measures." in messages
             )
 
             # proper measure type, but referenced variable does not exist
@@ -2321,8 +2347,9 @@ class TestCF1_7(BaseTestCase):
         score, out_of, messages = get_results(results)
         expected_message = (
             "The cell_measures attribute for variable PS is formatted incorrectly. "
-            "It should take the form of either 'area: cell_var' or 'volume: cell_var' "
-            "where cell_var is an existing name of a variable describing the cell measures."
+            "It should take the form of 'area: cell_var', 'volume: cell_var', or "
+            "multiple such pairs separated by spaces (e.g. 'area: a volume: v'), "
+            "where each cell_var is an existing variable describing the cell measures."
         )
         assert expected_message in messages
 

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -654,8 +654,8 @@ class TestCF1_6(BaseTestCase):
         score, out_of, messages = get_results(results)
         assert "Cell measure variable cell_area2 must have dimensions which are a subset of those defined in variable PS." in messages
 
-        # CF 1.11 §7.2: a variable may carry multiple cell_measures entries,
-        # one per measure type. Both entries should validate.
+        # CF §7.2 allows a list of "measure: name" pairs, so a variable may
+        # carry more than one entry. Both should validate.
         dataset_multi = MockTimeSeries()
         dataset_multi.createVariable("PS", "d", ("time",))
         dataset_multi.variables["PS"].setncattr(
@@ -669,8 +669,8 @@ class TestCF1_6(BaseTestCase):
         score, out_of, messages = get_results(results)
         assert score == out_of and score > 0, f"multi-measure case should pass but got messages: {messages}"
 
-        # CF 1.11 §7.2: each measure type may appear at most once. Reject a
-        # second 'area:' entry as malformed.
+        # Two entries of the same measure type would have to disagree, so a
+        # second 'area:' is rejected. See the note in cf_1_6.py.
         dataset_multi.variables["PS"].setncattr(
             "cell_measures",
             "area: area_var area: area_var",


### PR DESCRIPTION
The existing `_cell_measures_core` regex in `cf/cf_1_6.py` matched the entire attribute as a single `measure: var` pair via `regex.match`, so any file with two measures was flagged as formatted incorrectly even though CF 1.11 §7.2 explicitly allows multiple:

```
cell_measures = 'area: cell_area volume: cell_volume'
```

CMIP7's ocean branded variables (`hfx`, `hfy`, `masscello`, `sfx`, `sfy`, etc.) ship the registered `cell_measures = 'area: areacello volume: volcello'` verbatim, and every one of those files currently fails §7.2 even though the value is canonical.

This PR refactors `_cell_measures_core` to use `regex.finditer` over `measure: var` pairs, walk each pair, and reject if the regex doesn't cover the full attribute (so malformed inputs like `area:` with no var or random trailing junk still fail). It also enforces the §7.2 rule that each measure type may appear at most once (a second `area:` entry is a failure).

Verified locally on a CMIP7 file with `cell_measures = 'area: areacello volume: volcello'`. The §7.2 false-positive is gone. The only remaining failure is the downstream "var not in dataset" check, which is correctly handled by `CF1_7Check`'s `external_variables` path.