### PR TITLE
cf §7.3.4: accept collapsed-dim names in cell_methods without coord vars

### DIFF
--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -22,6 +22,27 @@ from compliance_checker.cfunits import Unit
 logger = logging.getLogger(__name__)
 
 
+# CF §7.3.4: when an operation in cell_methods applies to a "collapsed"
+# dimension that doesn't have an explicit coordinate variable, the name
+# component may be one of these reserved tokens instead of a dim or
+# coord variable name. Spec text (CF 1.13 §7.3.4):
+#   "the strings 'area:' or 'longitude:', 'latitude:' (in lieu of a
+#    2-D or scalar lat/lon coordinate) may be used; for vertical,
+#    'height:', 'altitude:', 'depth:', 'pressure:' may be used (in
+#    lieu of a vertical scalar coordinate)."
+CF_NO_COORDINATE_NAMES = frozenset(
+    {
+        "area",
+        "longitude",
+        "latitude",
+        "height",
+        "altitude",
+        "depth",
+        "pressure",
+    },
+)
+
+
 class CF1_6Check(CFNCCheck):
     """CF-1.6-specific implementation of CFBaseCheck; supports checking
     netCDF datasets.
@@ -2959,14 +2980,16 @@ class CF1_6Check(CFNCCheck):
                 for var_raw_str in match.captures("vars"):
                     # strip off the ' :' at the end of each match
                     var_str = var_raw_str[:-2]
-                    if var_str in var.dimensions or var_str == "area" or var_str in getattr(var, "coordinates", ""):
+                    if var_str in var.dimensions or var_str in CF_NO_COORDINATE_NAMES or var_str in getattr(var, "coordinates", ""):
                         valid = True
                     else:
                         valid = False
 
                     valid_cell_names.assert_true(
                         valid,
-                        f"{var.name}'s cell_methods name component {var_str} does not match a dimension, area or auxiliary coordinate",
+                        f"{var.name}'s cell_methods name component {var_str} does not match a dimension, "
+                        "auxiliary coordinate, or one of the CF §7.3.4 collapsed-dimension names "
+                        f"({', '.join(sorted(CF_NO_COORDINATE_NAMES))})",
                     )
 
             ret_val.append(valid_cell_names.to_result())

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -1753,9 +1753,22 @@ class TestCF1_6(BaseTestCase):
         temp = nc_obj.variables["temperature"]
         temp.cell_methods = "lat: lon: mean depth: mean (interval: 20 meters)"
         results = self.cf.check_cell_methods(nc_obj)
-        # invalid components lat, lon, and depth -- expect score == (6, 9)
+        # invalid components 'lat' and 'lon' (the spec uses 'latitude' /
+        # 'longitude' as the CF §7.3.4 collapsed-dim tokens, not the
+        # abbreviated forms). 'depth' is one of the §7.3.4 reserved names
+        # and IS valid even though the variable has no explicit depth
+        # coord. Total: 2 invalid components, so score != out_of.
         scored, out_of, messages = get_results(results)
         assert scored != out_of
+
+        # CF §7.3.4 collapsed-dim tokens: each one should validate without
+        # an explicit coordinate variable, mirroring the existing 'area'
+        # special case. Regression for the previously-missing names.
+        for token in ("longitude", "latitude", "height", "altitude", "depth", "pressure"):
+            temp.cell_methods = f"{token}: time: mean"
+            results = self.cf.check_cell_methods(nc_obj)
+            scored, out_of, messages = get_results(results)
+            assert scored == out_of, f"§7.3.4 collapsed-dim token {token!r} should validate but messages were: {messages}"
 
         temp.cell_methods = "lat: lon: mean depth: mean (interval: x whizbangs)"
         results = self.cf.check_cell_methods(nc_obj)


### PR DESCRIPTION
CF 1.13 §7.3.4 ("Cell methods when there are no coordinates") lists seven reserved tokens that may appear as cell_methods name components even when the file has no explicit coordinate variable for the named dimension:

> the strings `area:` or `longitude:`, `latitude:` (in lieu of a 2-D or scalar lat/lon coordinate) may be used; for vertical, `height:`, `altitude:`, `depth:`, `pressure:` may be used (in lieu of a vertical scalar coordinate).

The current check in `cf_1_6.py:check_cell_methods` only special-cases `area` and flags the other six (`longitude`, `latitude`, `height`, `altitude`, `depth`, `pressure`) as `"does not match a dimension, area or auxiliary coordinate"`. The feature parity matrix at `docs/source/cf_feature_parity_matrix.md:59` already lists §7.3.4 as `?`, so this gap is documented but not yet implemented.

Concrete impact: CMIP7's registered cell_methods for hemispheric atm-chem variables (`cfc11`/`ch4`/`n2o` on `tavg-u-hm-air`) carry `'height: area: time: mean (...)'`, and the ocean vertical-sum heat transports (`hfx`/`hfy` on `tavg-u-hxy-sea`) carry `'... depth: sum where sea ... time: mean'`. Both forms are CF-compliant per §7.3.4 but every published file currently emits a spurious MEDIUM finding.

This PR:
- Introduces `CF_NO_COORDINATE_NAMES` with the seven spec-listed tokens.
- Extends the name-component check to accept any token in that set in addition to dims and `coordinates` attr entries.
- Updates the existing `test_check_cell_methods` to reflect that `depth` alone is now valid (the file under test still uses `lat`/`lon` which aren't the CF-spec abbreviations and remain invalid).
- Adds a regression covering each of the six previously-missing tokens.

Related: #1323 (§7.2 multi-pair fix), same shape and same maintainer queue. Credit @taylor13 for spotting the spec text in a WCRP-universe discussion (WCRP-CMIP/WCRP-universe#194).