### PR TITLE
cf §2.4: don't order-check the formula_terms bounds of a parametric vertical coordinate

### DIFF
--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -344,6 +344,55 @@ class CF1_6Check(CFNCCheck):
             msgs=fails,
         )
 
+    @staticmethod
+    def _get_formula_terms_bounds_variables(ds, bounds_variables):
+        """
+        Returns the set of variables that hold the bounds of the terms of a
+        parametric vertical coordinate.
+
+        CF §4.3.3 requires the boundary variable of a parametric vertical
+        coordinate to carry its own ``formula_terms``, in which the terms that
+        depend on the vertical dimension name a *different* variable than the
+        coordinate's own ``formula_terms`` does::
+
+            lev:formula_terms      = "ap: ap b: b ps: ps" ;
+            lev_bnds:formula_terms = "ap: ap_bnds b: b_bnds ps: ps" ;
+
+        ``ap_bnds`` and ``b_bnds`` are bounds variables, but they are named by
+        ``formula_terms`` rather than by a ``bounds`` attribute, so
+        :func:`~compliance_checker.cf.util.get_cell_boundary_variables` does
+        not find them.
+
+        Terms that do not depend on the vertical dimension keep the same name
+        in both attributes (``ps`` above). Those are ordinary variables and
+        must not be treated as bounds, so only the names that differ between
+        the two attributes are returned.
+
+        :param netCDF4.Dataset ds: An open netCDF dataset
+        :param bounds_variables: names of the variables named by a ``bounds``
+                                 attribute
+        :rtype: set
+        """
+        formula_bounds = set()
+        for parent in ds.variables.values():
+            bounds_name = getattr(parent, "bounds", None)
+            if bounds_name not in bounds_variables:
+                continue
+            bounds_var = ds.variables.get(bounds_name)
+            if bounds_var is None:
+                continue
+            parent_terms = getattr(parent, "formula_terms", None)
+            bounds_terms = getattr(bounds_var, "formula_terms", None)
+            if not bounds_terms:
+                continue
+            # Same tokenisation as _check_formula_terms: the variable name is
+            # the second group of each "component: variable_name" pair.
+            pattern = r"(\w+):\s+(\w+)(?:\s+(?!$)|$)"
+            bounds_named = {m.group(2) for m in regex.finditer(pattern, bounds_terms)}
+            parent_named = {m.group(2) for m in regex.finditer(pattern, parent_terms or "")}
+            formula_bounds |= (bounds_named - parent_named) & set(ds.variables)
+        return formula_bounds
+
     def check_dimension_order(self, ds):
         """
         Checks each variable's dimension order to ensure that the order is
@@ -365,14 +414,16 @@ class CF1_6Check(CFNCCheck):
         coord_axis_map = self._get_coord_axis_map(ds)
 
         # Check each variable's dimension order, excluding climatology and
-        # bounds variables
+        # bounds variables (including the formula_terms bounds of a
+        # parametric vertical coordinate, see CF §4.3.3)
         any_clim = cfutil.get_climatology_variable(ds)
         any_bounds = cfutil.get_cell_boundary_variables(ds)
+        any_formula_bounds = self._get_formula_terms_bounds_variables(ds, any_bounds)
         for name, variable in ds.variables.items():
             # Skip bounds/climatology variables, as they should implicitly
             # have the same order except for the bounds specific dimension.
             # This is tested later in the respective checks
-            if name in any_bounds or name == any_clim:
+            if name in any_bounds or name in any_formula_bounds or name == any_clim:
                 continue
 
             # Skip strings/labels

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -350,6 +350,79 @@ class TestCF1_6(BaseTestCase):
         assert (3, 3) == result.value
         assert [] == result.msgs
 
+    @staticmethod
+    def _hybrid_sigma_dataset(ps_dims=("time", "lat", "lon")):
+        """Minimal parametric vertical coordinate with CF §4.3.3 bounds."""
+        ds = MockNetCDF()
+        ds.createDimension("time", 1)
+        ds.createDimension("lev", 2)
+        ds.createDimension("lat", 2)
+        ds.createDimension("lon", 2)
+        ds.createDimension("bnds", 2)
+
+        time = ds.createVariable("time", "d", ("time",))
+        time.standard_name = "time"
+        time.units = "days since 2000-01-01"
+        time.axis = "T"
+        lat = ds.createVariable("lat", "d", ("lat",))
+        lat.standard_name = "latitude"
+        lat.units = "degrees_north"
+        lat.axis = "Y"
+        lon = ds.createVariable("lon", "d", ("lon",))
+        lon.standard_name = "longitude"
+        lon.units = "degrees_east"
+        lon.axis = "X"
+
+        lev = ds.createVariable("lev", "d", ("lev",))
+        lev.standard_name = "atmosphere_hybrid_sigma_pressure_coordinate"
+        lev.units = "1"
+        lev.axis = "Z"
+        lev.positive = "down"
+        lev.formula_terms = "ap: ap b: b ps: ps"
+        lev.bounds = "lev_bnds"
+
+        lev_bnds = ds.createVariable("lev_bnds", "d", ("lev", "bnds"))
+        # The vertical-dependent terms name different variables here; ps does
+        # not depend on the vertical dimension and keeps its name.
+        lev_bnds.formula_terms = "ap: ap_bnds b: b_bnds ps: ps"
+
+        ds.createVariable("ap", "d", ("lev",))
+        ds.createVariable("b", "d", ("lev",))
+        ds.createVariable("ap_bnds", "d", ("lev", "bnds"))
+        ds.createVariable("b_bnds", "d", ("lev", "bnds"))
+
+        ps = ds.createVariable("ps", "f", ps_dims)
+        ps.standard_name = "surface_air_pressure"
+        ps.units = "Pa"
+        ta = ds.createVariable("ta", "f", ("time", "lev", "lat", "lon"))
+        ta.standard_name = "air_temperature"
+        ta.units = "K"
+        return ds
+
+    def test_check_dimension_order_formula_terms_bounds(self):
+        """
+        CF §4.3.3: the boundary variable of a parametric vertical coordinate
+        carries its own formula_terms naming the bounds of each vertical-
+        dependent term (ap_bnds, b_bnds). Those are bounds variables and must
+        not be subject to the §2.4 dimension order recommendation, even though
+        they are named by formula_terms rather than by a bounds attribute.
+        """
+        dataset = self._hybrid_sigma_dataset()
+        result = self.cf.check_dimension_order(dataset)
+        assert [] == result.msgs
+        assert result.value[0] == result.value[1]
+
+    def test_check_dimension_order_formula_terms_shared_variable(self):
+        """
+        Terms that do not depend on the vertical dimension keep the same name
+        in both formula_terms attributes (ps). Those are ordinary variables and
+        must still be checked, otherwise the exclusion hides real findings.
+        """
+        dataset = self._hybrid_sigma_dataset(ps_dims=("lat", "time", "lon"))
+        result = self.cf.check_dimension_order(dataset)
+        assert any(msg.startswith("ps's") for msg in result.msgs)
+        assert not any(msg.startswith(("ap_bnds's", "b_bnds's")) for msg in result.msgs)
+
     def test_check_fill_value_equal_missing_value(self):
         """
         According to CF §2.5.1 Recommendations: If both missing_value and _FillValue be used,


### PR DESCRIPTION
Splits the second, unrelated half out of #1345 so it can be reviewed on its own. This one is a plain bug against the existing intent of the code, not a policy question, and does not depend on the outcome of the other half.

`check_dimension_order` already means to skip bounds variables:

```python
# Skip bounds/climatology variables, as they should implicitly
# have the same order except for the bounds specific dimension.
if name in any_bounds or name == any_clim:
```

but `get_cell_boundary_variables` only collects variables named by a `bounds` **attribute**. CF §4.3.3 puts the bounds of each term of a parametric vertical coordinate on the boundary variable's own `formula_terms`:

```
lev:formula_terms      = "ap: ap b: b ps: ps" ;
lev_bnds:formula_terms = "ap: ap_bnds b: b_bnds ps: ps" ;
```

so `ap_bnds` and `b_bnds` never reach that exclusion and are order-checked as ordinary variables. `(lev, bnds)` types as `ZU` and fails, on every file carrying a hybrid sigma coordinate.

### The `ps` subtlety

Terms that do not depend on the vertical dimension keep the same name in both attributes (`ps` above), which CF §4.3.3 spells out: the boundary variable's `formula_terms` must name a *different* variable only "except for terms that depend on the vertical dimension".

`ps` is an ordinary data variable and must stay in the order check, otherwise the exclusion would hide real findings. So only the names that **differ** between the coordinate's and the bounds' `formula_terms` are excluded. Tokenised with the same `(\w+):\s+(\w+)` pattern `_check_formula_terms` already uses.

### Verification

Both rows below come from a 16 KB file built from the CDL at the end of this description:

| file | before | after |
|---|---|---|
| hybrid sigma coordinate | 2 findings (`ap_bnds`, `b_bnds`) | **0** |
| same, with `ps` deliberately misordered to `(lat, time, lon)` | 3 findings | **1** (`ps`) |

Two regression tests, one per row; both fail without the change. `test_cf.py` goes from 116 passed to 118 passed, no failures. `ruff check` and `ruff format --check` clean.

### Reproducer

No attachment needed, this is the whole thing:

```
netcdf formula_bnds {
dimensions:
	time = 1 ;
	lev = 2 ;
	lat = 2 ;
	lon = 2 ;
	bnds = 2 ;
variables:
	double time(time) ;
		time:standard_name = "time" ;
		time:units = "days since 2000-01-01" ;
		time:calendar = "proleptic_gregorian" ;
		time:axis = "T" ;
	double lat(lat) ;
		lat:standard_name = "latitude" ;
		lat:units = "degrees_north" ;
		lat:axis = "Y" ;
	double lon(lon) ;
		lon:standard_name = "longitude" ;
		lon:units = "degrees_east" ;
		lon:axis = "X" ;
	double lev(lev) ;
		lev:standard_name = "atmosphere_hybrid_sigma_pressure_coordinate" ;
		lev:units = "1" ;
		lev:axis = "Z" ;
		lev:positive = "down" ;
		lev:formula_terms = "ap: ap b: b ps: ps" ;
		lev:bounds = "lev_bnds" ;
	double lev_bnds(lev, bnds) ;
		lev_bnds:formula_terms = "ap: ap_bnds b: b_bnds ps: ps" ;
	double ap(lev) ;
		ap:units = "Pa" ;
	double b(lev) ;
		b:units = "1" ;
	double ap_bnds(lev, bnds) ;
		ap_bnds:units = "Pa" ;
	double b_bnds(lev, bnds) ;
		b_bnds:units = "1" ;
	float ps(time, lat, lon) ;
		ps:standard_name = "surface_air_pressure" ;
		ps:units = "Pa" ;
	float ta(time, lev, lat, lon) ;
		ta:standard_name = "air_temperature" ;
		ta:units = "K" ;
// global attributes:
		:Conventions = "CF-1.8" ;
		:title = "minimal formula_terms bounds reproducer" ;
data:
 time = 0 ;
 lat = -45, 45 ;
 lon = 0, 180 ;
 lev = 0.5, 0.9 ;
 lev_bnds = 0.3,0.7, 0.7,1.0 ;
 ap = 100, 50 ;
 b = 0.4, 0.85 ;
 ap_bnds = 120,80, 80,20 ;
 b_bnds = 0.2,0.6, 0.6,0.9 ;
 ps = 101000, 101000, 101000, 101000 ;
 ta = 250,251,252,253, 254,255,256,257 ;
}
```

```
ncgen -k nc4 -o formula_bnds.nc formula_bnds.cdl
compliance-checker --test cf:1.8 -f text formula_bnds.nc
```

Related: #1345 (the other, separate half), #1323, #1324.
