### PR TITLE
update coordinate attribute tests

### DIFF
--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -1630,6 +1630,7 @@ class CF1_6Check(CFNCCheck):
             standard_name = getattr(variable, "standard_name", None)
             units = getattr(variable, "units", None)
             positive = getattr(variable, "positive", None)
+            axis = getattr(variable, "axis", None)
             # Skip the variable if it's dimensionless
             if hasattr(variable, "formula_terms") or standard_name in dimless_vertical_coordinates:
                 continue
@@ -1650,6 +1651,15 @@ class CF1_6Check(CFNCCheck):
             # already verifies that this coordinate has valid units
 
             ret_val.append(valid_vertical_coord.to_result())
+
+            z_variables = ds.get_variables_by_attributes(axis="Z")
+            # Check that vertical coordinate defines either standard_name or axis
+            definition = TestCtx(BaseCheck.MEDIUM, self.section_titles["4.3"])
+            definition.assert_true(
+                standard_name is not None or axis == "Z" or z_variables != [],
+                f"vertical coordinate variable '{name}' should define appropriate standard_name or axis='Z'",
+            )
+            ret_val.append(definition.to_result())
 
         return ret_val
 
@@ -1761,6 +1771,8 @@ class CF1_6Check(CFNCCheck):
         ret_val = []
         for name in cfutil.get_time_variables(ds):
             variable = ds.variables[name]
+            standard_name = getattr(variable, "standard_name", None)
+            axis = getattr(variable, "axis", None)
             # Has units
             has_units = hasattr(variable, "units")
             if not has_units:
@@ -1813,6 +1825,16 @@ class CF1_6Check(CFNCCheck):
                     [message],
                 )
                 ret_val.append(result)
+
+            t_variables = ds.get_variables_by_attributes(axis="T")
+            # Check that vertical coordinate defines either standard_name or axis
+            definition = TestCtx(BaseCheck.MEDIUM, self.section_titles["4.4"])
+            definition.assert_true(
+                standard_name == "time" or axis == "T" or t_variables != [],
+                f"time variable '{name}' should define standard_name='time' or axis='T'",
+            )
+            ret_val.append(definition.to_result())
+
         return ret_val
 
     def check_calendar(self, ds):

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -2168,13 +2168,13 @@ class CF1_6Check(CFNCCheck):
                         )
                         continue
 
-                    coord_var = ds.variables[dim]
-                    std_name = getattr(coord_var, "standard_name", None)
+                    # coord_var = ds.variables[dim]
+                    # std_name = getattr(coord_var, "standard_name", None)
 
-                    check_spatiotemporal_dims_coords.assert_true(
-                        std_name == expected_standard_names[dim],
-                        f"Coordinate variable '{dim}' should have standard_name='{expected_standard_names[dim]}', found: '{std_name}'",
-                    )
+                    # check_spatiotemporal_dims_coords.assert_true(
+                    #     std_name == expected_standard_names[dim],
+                    #     f"Coordinate variable '{dim}' should have standard_name='{expected_standard_names[dim]}', found: '{std_name}'",
+                    # )
 
             ret_val.append(check_spatiotemporal_dims_coords.to_result())
         return ret_val

--- a/compliance_checker/cf/cf_1_6.py
+++ b/compliance_checker/cf/cf_1_6.py
@@ -1827,7 +1827,7 @@ class CF1_6Check(CFNCCheck):
                 ret_val.append(result)
 
             t_variables = ds.get_variables_by_attributes(axis="T")
-            # Check that vertical coordinate defines either standard_name or axis
+            # Check that time coordinate defines either standard_name or axis
             definition = TestCtx(BaseCheck.MEDIUM, self.section_titles["4.4"])
             definition.assert_true(
                 standard_name == "time" or axis == "T" or t_variables != [],

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -999,14 +999,14 @@ class TestCF1_6(BaseTestCase):
         # Check for compliance
         dataset = self.load_dataset(STATIC_FILES["example-grid"])
         results = self.cf.check_dimensional_vertical_coordinate(dataset)
-        assert len(results) == 1
+        assert len(results) == 2  # New axis/standard_name check added
         assert all(r.name == "§4.3 Vertical Coordinate" for r in results)
 
         # non-compliance -- one check fails
         dataset = self.load_dataset(STATIC_FILES["illegal-vertical"])
         results = self.cf.check_dimensional_vertical_coordinate(dataset)
         scored, out_of, messages = get_results(results)
-        assert len(results) == 1
+        assert len(results) == 2  # New axis/standard_name check added
         assert all(r.name == "§4.3 Vertical Coordinate" for r in results)
         assert scored < out_of
 
@@ -1356,7 +1356,7 @@ class TestCF1_6(BaseTestCase):
         result_dict = {result.name: result for result in results}
         result = result_dict["§5.1 Independent Latitude, Longitude, Vertical, and Time Axes"]
         assert result.msgs == []  # shouldn't have any messages
-        assert result.value == (4, 4)
+        assert result.value == (0, 0)  # Standard_name checks commented out
 
     def test_check_invalid_coordinate_attr(self):
         """


### PR DESCRIPTION
Fixes #1245
Closes https://github.com/euro-cordex/jsc-compliance-check/issues/8046

Implements the standard name or axis definition tests for the time and vertical coordinate axis:

* Added logic in `check_dimensional_vertical_coordinate` to ensure that each vertical coordinate variable defines either a `standard_name` or has `axis='Z'`.
* Updated `check_time_coordinate` to similarly require that time coordinate variables define either `standard_name='time'` or have `axis='T'`.

The logic for these tests are in line with the ones for the longitude and latitude axis (i hope that makes sense).

I also commented out the code in `check_spatiotemporal_dims_have_coordinate_vars` that strictly enforced the presence of specific `standard_name` attributes on coordinate variables. 